### PR TITLE
Use real passowrd_hash functionality else mark skipped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,12 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "ircmaxell/password-compat": "~1.0.0"
+    },
+    "suggest": {
+        "ircmaxell/password-compat": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash"
+    },
     "autoload": {
         "psr-4": {
             "Aura\\Auth\\": "src/"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,12 +2,7 @@
 // autoloader
 require dirname(__DIR__) . '/autoload.php';
 
-// default globals
-if (is_readable(__DIR__ . '/globals.dist.php')) {
-    require __DIR__ . '/globals.dist.php';
-}
-
-// override globals
-if (is_readable(__DIR__ . '/globals.php')) {
-    require __DIR__ . '/globals.php';
+// load composer autoload. Good to test password_hash really by ircmaxell/password-compat
+if (is_readable(dirname(__DIR__) . '/vendor/autoload.php')) {
+    require dirname(__DIR__) . '/vendor/autoload.php';
 }

--- a/tests/src/Verifier/PasswordVerifierTest.php
+++ b/tests/src/Verifier/PasswordVerifierTest.php
@@ -1,21 +1,6 @@
 <?php
 namespace Aura\Auth\Verifier;
 
-/**
- * For PHP < 5.5 without ircmaxell/password_compat, fake the password_hash()
- * and password_verify() functions.
- */
-if (! defined('PASSWORD_BCRYPT')) {
-    function password_hash($plaintext, $algo, array $opts = array())
-    {
-        return hash($algo, $plaintext);
-    }
-    function password_verify($password, $hash)
-    {
-        return md5($password) === $hash;
-    }
-}
-
 class PasswordVerifierTest extends \PHPUnit_Framework_TestCase
 {
     public function test()
@@ -25,7 +10,7 @@ class PasswordVerifierTest extends \PHPUnit_Framework_TestCase
             $algo = PASSWORD_BCRYPT;
         } else {
             // use the fake password_hash()
-            $algo = 'md5';
+            $this->markTestIncomplete("password_hash functionality not available. Install ircmaxell/password-compat for 5.3+");
         }
 
         $verifier = new PasswordVerifier($algo);


### PR DESCRIPTION
It is good to add password_hash in suggest and require-dev for better password. There are still many people who are unaware of better hashing and the latest things in php world. 

So promoting the good I am strongly for merging this. Though you have not said a word against  ( @pmjones ) .
