### PR TITLE
Finish IMAP and LDAP adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,8 @@ try {
 ?>
 ```
 
+**TBD: _ConnectionFailed_ for IMAP/LDAP, and _BindFailed_ for LDAP**
+
 > N.b.: Instead of creating the  _Auth_ and _LoginService_ objects by hand, you may wish to use a dependency injection container such as [Aura.Di](https://github.com/auraphp/Aura.Di) to retain them for shared use throughout your application.
 
 Alternatively, you may wish to use credentials from the HTTP `Authorization: Basic` headers instead of using `$_POST` or other form-related inputs.  On Apache `mod_php` you might use the auto-populated `$_SERVER['PHP_AUTH_*']` values:
@@ -474,9 +476,9 @@ use Aura\Auth\Auth;
 class CustomAdapter implements AdapterInterface
 {
     // AdapterInterface::login()
-    public function login(array $cred)
+    public function login(array $input)
     {
-        if ($this->isLegit($cred)) {
+        if ($this->isLegit($input)) {
             $username = ...;
             $userdata = array(...);
             $this->updateLoginTime(time());
@@ -499,7 +501,7 @@ class CustomAdapter implements AdapterInterface
     }
 
     // custom support methods not in the interface
-    protected function isLegit($credentials) { ... }
+    protected function isLegit($input) { ... }
 
     protected function updateLoginTime($time) { ... }
 

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -46,12 +46,12 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      *
-     * @param mixed $cred
+     * @param mixed $input
      *
      * @return bool
      *
      */
-    abstract public function login(array $cred);
+    abstract public function login(array $input);
 
     /**
      *
@@ -83,18 +83,18 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      *
-     * @param array $cred
+     * @param array $input
      *
      * @return bool
      *
      */
-    protected function checkCredentials(&$cred)
+    protected function checkInput(&$input)
     {
-        if (empty($cred['username'])) {
+        if (empty($input['username'])) {
             throw new Exception\UsernameMissing;
         }
 
-        if (empty($cred['password'])) {
+        if (empty($input['password'])) {
             throw new Exception\PasswordMissing;
         }
     }

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -30,12 +30,12 @@ interface AdapterInterface
 
     /**
      *
-     * @param array $cred
+     * @param array $input
      *
      * @return null
      *
      */
-    public function login(array $cred);
+    public function login(array $input);
 
     /**
      *

--- a/src/Adapter/HtpasswdAdapter.php
+++ b/src/Adapter/HtpasswdAdapter.php
@@ -59,14 +59,14 @@ class HtpasswdAdapter extends AbstractAdapter
      *
      * Verifies set of credentials.
      *
-     * @param array $cred A list of credentials to verify
+     * @param array $input A list of credentials to verify
      *
      */
-    public function login(array $cred)
+    public function login(array $input)
     {
-        $this->checkCredentials($cred);
-        $username = $cred['username'];
-        $password = $cred['password'];
+        $this->checkInput($input);
+        $username = $input['username'];
+        $password = $input['password'];
         $hashvalue = $this->fetchEncrypted($username);
         $this->verify($password, $hashvalue);
         return array($username, array());

--- a/src/Adapter/ImapAdapter.php
+++ b/src/Adapter/ImapAdapter.php
@@ -11,7 +11,7 @@
 namespace Aura\Auth\Adapter;
 
 use Aura\Auth\Exception;
-use Aura\Auth\FunctionProxy;
+use Aura\Auth\Phpfunc;
 
 /**
  *
@@ -38,19 +38,19 @@ class ImapAdapter extends AbstractAdapter
 
     protected $params;
 
-    protected $proxy;
+    protected $phpfunc;
 
     public function __construct(
-        FunctionProxy $proxy,
+        Phpfunc $phpfunc,
         $mailbox,
         $options = 0,
-        $attempt = 1,
+        $retries = 1,
         array $params = null
     ) {
-        $this->proxy = $proxy;
+        $this->phpfunc = $phpfunc;
         $this->mailbox = $mailbox;
         $this->options = $options;
-        $this->attempt = $attempt;
+        $this->retries = $retries;
         $this->params = $params;
     }
 
@@ -58,24 +58,24 @@ class ImapAdapter extends AbstractAdapter
      *
      * Log in with username/password credentials.
      *
-     * @param array $cred An array of credential data, including any data to
+     * @param array $input An array of credential data, including any data to
      * bind to the query.
      *
      * @return bool True on success, false on failure.
      *
      */
-    public function login(array $cred)
+    public function login(array $input)
     {
-        $this->checkCredentials($cred);
-        $username = $cred['username'];
-        $password = $cred['password'];
+        $this->checkInput($input);
+        $username = $input['username'];
+        $password = $input['password'];
 
-        $conn = $this->proxy->imap_open(
+        $conn = $this->phpfunc->imap_open(
             $this->mailbox,
             $username,
             $password,
             $this->options,
-            $this->attempt,
+            $this->retries,
             $this->params
         );
 
@@ -83,7 +83,7 @@ class ImapAdapter extends AbstractAdapter
             throw new Exception\ConnectionFailed($this->mailbox);
         }
 
-        $this->proxy->imap_close($conn);
+        $this->phpfunc->imap_close($conn);
         return array($username, array());
     }
 }

--- a/src/Adapter/ImapAdapter.php
+++ b/src/Adapter/ImapAdapter.php
@@ -79,11 +79,11 @@ class ImapAdapter extends AbstractAdapter
             $this->params
         );
 
-        if (is_resource($conn)) {
-            $this->proxy->imap_close($conn);
-            return array($username, array());
+        if (! $conn) {
+            throw new Exception\ConnectionFailed($this->mailbox);
         }
 
-        throw new Exception\ConnectionFailed($this->mailbox);
+        $this->proxy->imap_close($conn);
+        return array($username, array());
     }
 }

--- a/src/Adapter/LdapAdapter.php
+++ b/src/Adapter/LdapAdapter.php
@@ -98,9 +98,11 @@ class LdapAdapter extends AbstractAdapter
             return array('username' => $username);
         }
 
-        $e = new Exception\ConnectionFailed(
-            $this->proxy->ldap_errno($conn) . ': ' . $this->proxy->ldap_error($conn)
-        );
+        // bind failed
+        $message = $this->proxy->ldap_errno($conn)
+                 . ': '
+                 . $this->proxy->ldap_error($conn);
+        $e = new Exception\ConnectionFailed($message);
         $this->proxy->ldap_close($conn);
         throw $e;
     }

--- a/src/Adapter/NullAdapter.php
+++ b/src/Adapter/NullAdapter.php
@@ -23,12 +23,12 @@ class NullAdapter extends AbstractAdapter
      *
      * login
      *
-     * @param array $cred
+     * @param array $input
      *
      * @return array
      *
      */
-    public function login(array $cred)
+    public function login(array $input)
     {
         return array(null, null);
     }

--- a/src/Adapter/PdoAdapter.php
+++ b/src/Adapter/PdoAdapter.php
@@ -106,17 +106,17 @@ class PdoAdapter extends AbstractAdapter
      *
      * Log in with username/password credentials.
      *
-     * @param array $cred An array of credential data, including any data to
+     * @param array $input An array of credential data, including any data to
      * bind to the query.
      *
      * @return bool True on success, false on failure.
      *
      */
-    public function login(array $cred)
+    public function login(array $input)
     {
-        $this->checkCredentials($cred);
-        $data = $this->fetchRow($cred);
-        $this->verify($cred, $data);
+        $this->checkInput($input);
+        $data = $this->fetchRow($input);
+        $this->verify($input, $data);
         $name = $data['username'];
         unset($data['username']);
         unset($data['password']);
@@ -127,15 +127,15 @@ class PdoAdapter extends AbstractAdapter
      *
      * Fetch a row from the table
      *
-     * @param array $cred
+     * @param array $input
      *
      * @return array
      *
      */
-    protected function fetchRow($cred)
+    protected function fetchRow($input)
     {
         $stm = $this->buildSelect();
-        $rows = $this->fetchRows($stm, $cred);
+        $rows = $this->fetchRows($stm, $input);
 
         if (count($rows) < 1) {
             throw new Exception\UsernameNotFound;
@@ -228,10 +228,10 @@ class PdoAdapter extends AbstractAdapter
      * @return bool
      *
      */
-    protected function verify($cred, $data)
+    protected function verify($input, $data)
     {
         $verified = $this->verifier->verify(
-            $cred['password'],
+            $input['password'],
             $data['password'],
             $data
         );

--- a/src/Exception/BindFailed.php
+++ b/src/Exception/BindFailed.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @package Aura.Auth
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Auth\Exception;
+
+use Aura\Auth\Exception;
+
+/**
+ *
+ * Binding to a network service (LDAP etc) failed.
+ *
+ * @package Aura.Auth
+ *
+ */
+class BindFailed extends Exception
+{
+}

--- a/src/FunctionProxy.php
+++ b/src/FunctionProxy.php
@@ -22,11 +22,11 @@ class FunctionProxy
 {
     /**
      *
-     * __call
+     * Magic call for PHP functions.
      *
-     * @param string $method
+     * @param string $method The PHP function to call.
      *
-     * @param array $params
+     * @param array $params Params to pass to the function.
      *
      * @return mixed
      *

--- a/src/Phpfunc.php
+++ b/src/Phpfunc.php
@@ -18,7 +18,7 @@ namespace Aura\Auth;
  *
  */
 
-class FunctionProxy
+class Phpfunc
 {
     /**
      *

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -63,14 +63,14 @@ class LoginService
      *
      * @param Auth $auth
      *
-     * @param array $cred
+     * @param array $input
      *
      * @return void
      *
      */
-    public function login(Auth $auth, array $cred)
+    public function login(Auth $auth, array $input)
     {
-        list($name, $data) = $this->adapter->login($cred);
+        list($name, $data) = $this->adapter->login($input);
         $this->forceLogin($auth, $name, $data);
     }
 

--- a/tests/src/Adapter/FakeAdapter.php
+++ b/tests/src/Adapter/FakeAdapter.php
@@ -13,8 +13,8 @@ class FakeAdapter extends AbstractAdapter
         $this->accounts = $accounts;
     }
 
-    public function login(array $cred)
+    public function login(array $input)
     {
-        return array($cred['username'], array());
+        return array($input['username'], array());
     }
 }

--- a/tests/src/Adapter/ImapAdapterTest.php
+++ b/tests/src/Adapter/ImapAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Auth\Adapter;
 
-use Aura\Auth\FunctionProxy;
+use Aura\Auth\Phpfunc;
 
 class ImapAdapterTest extends \PHPUnit_Framework_TestCase
 {
@@ -10,7 +10,7 @@ class ImapAdapterTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->adapter = new ImapAdapter(
-            new FunctionProxy,
+            new Phpfunc,
             '{mailbox.example.com:143/imap/secure}'
         );
     }

--- a/tests/src/Adapter/ImapAdapterTest.php
+++ b/tests/src/Adapter/ImapAdapterTest.php
@@ -5,12 +5,22 @@ use Aura\Auth\Phpfunc;
 
 class ImapAdapterTest extends \PHPUnit_Framework_TestCase
 {
+    protected $phpfunc;
+
     protected $adapter;
 
     protected function setUp()
     {
+        $this->phpfunc = $this->getMock(
+            'Aura\Auth\Phpfunc',
+            array(
+                'imap_open',
+                'imap_close',
+            )
+        );
+
         $this->adapter = new ImapAdapter(
-            new Phpfunc,
+            $this->phpfunc,
             '{mailbox.example.com:143/imap/secure}'
         );
     }
@@ -21,5 +31,43 @@ class ImapAdapterTest extends \PHPUnit_Framework_TestCase
             'Aura\Auth\Adapter\ImapAdapter',
             $this->adapter
         );
+    }
+
+    public function testLogin()
+    {
+        $this->phpfunc->expects($this->once())
+            ->method('imap_open')
+            ->with(
+                '{mailbox.example.com:143/imap/secure}',
+                'someusername',
+                'secretpassword',
+                0,
+                1,
+                null
+            )
+            ->will($this->returnValue(true));
+
+        $actual = $this->adapter->login(array(
+            'username' => 'someusername',
+            'password' => 'secretpassword'
+        ));
+
+        $expect = array('someusername', array());
+
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testLogin_connectionFailed()
+    {
+        $this->phpfunc->expects($this->once())
+            ->method('imap_open')
+            ->with('{mailbox.example.com:143/imap/secure}')
+            ->will($this->returnValue(false));
+
+        $this->setExpectedException('Aura\Auth\Exception\ConnectionFailed');
+        $this->adapter->login(array(
+            'username' => 'someusername',
+            'password' => 'secretpassword'
+        ));
     }
 }

--- a/tests/src/Adapter/LdapAdapterTest.php
+++ b/tests/src/Adapter/LdapAdapterTest.php
@@ -1,21 +1,22 @@
 <?php
 namespace Aura\Auth\Adapter;
 
-use Aura\Auth\FunctionProxy;
+use Aura\Auth\Phpfunc;
 
 class LdapAdapterTest extends \PHPUnit_Framework_TestCase
 {
     protected $adapter;
 
-    protected $proxy;
+    protected $phpfunc;
 
     protected function setUp()
     {
-        $this->proxy = $this->getMock(
-            'Aura\Auth\FunctionProxy',
+        $this->phpfunc = $this->getMock(
+            'Aura\Auth\Phpfunc',
             array(
                 'ldap_connect',
                 'ldap_bind',
+                'ldap_unbind',
                 'ldap_set_option',
                 'ldap_close',
                 'ldap_errno',
@@ -23,7 +24,13 @@ class LdapAdapterTest extends \PHPUnit_Framework_TestCase
             ),
             array()
         );
-        $this->adapter = new LdapAdapter($this->proxy, 'ldap.example.com', '');
+
+        $this->adapter = new LdapAdapter(
+            $this->phpfunc,
+            'ldaps://ldap.example.com:636',
+            'ou=Foo,dc=Bar,cn=users,uid=%s',
+            array('LDAP_OPTION_KEY', 'LDAP_OPTION_VALUE')
+        );
     }
 
     public function testInstance()
@@ -34,82 +41,91 @@ class LdapAdapterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     *
-     * @expectedException Aura\Auth\Exception\ConnectionFailed
-     *
-     */
     public function testLoginConnectionFailed()
     {
-        $cred = array(
+        $input = array(
             'username' => 'someusername',
             'password' => 'secretpassword'
         );
-        $this->proxy->expects($this->once())
+        $this->phpfunc->expects($this->once())
             ->method('ldap_connect')
-            ->with('ldap.example.com')
+            ->with('ldaps://ldap.example.com:636')
             ->will($this->returnValue(false));
-        $this->adapter->login($cred);
+
+        $this->setExpectedException('Aura\Auth\Exception\ConnectionFailed');
+        $this->adapter->login($input);
     }
 
     public function testLoginSuccess()
     {
-        $this->proxy->expects($this->once())
+        $this->phpfunc->expects($this->once())
             ->method('ldap_connect')
-            ->with('ldap.example.com')
+            ->with('ldaps://ldap.example.com:636')
             ->will($this->returnValue(true));
 
-        $this->proxy->expects($this->any())
+        $this->phpfunc->expects($this->any())
             ->method('ldap_set_option')
             ->will($this->returnValue(true));
 
-        $this->proxy->expects($this->once())
+        $this->phpfunc->expects($this->once())
             ->method('ldap_bind')
+            ->with(
+                true,
+                'ou=Foo,dc=Bar,cn=users,uid=someusername',
+                'secretpassword'
+            )
             ->will($this->returnValue(true));
 
-        $cred = array(
-            'username' => 'someusername',
-            'password' => 'secretpassword'
-        );
-        $this->assertEquals(array('username' => $cred['username']), $this->adapter->login($cred));
-    }
-
-    /**
-     *
-     * @expectedException Aura\Auth\Exception\ConnectionFailed
-     *
-     */
-    public function testUsernamePasswordFailure()
-    {
-        $this->proxy->expects($this->once())
-            ->method('ldap_connect')
-            ->with('ldap.example.com')
+        $this->phpfunc->expects($this->once())
+            ->method('ldap_unbind')
             ->will($this->returnValue(true));
 
-        $this->proxy->expects($this->any())
-            ->method('ldap_set_option')
-            ->will($this->returnValue(true));
-
-        $this->proxy->expects($this->once())
-            ->method('ldap_bind')
-            ->will($this->returnValue(false));
-
-        $this->proxy->expects($this->once())
-            ->method('ldap_error')
-            ->will($this->returnValue(400));
-
-        $this->proxy->expects($this->once())
-            ->method('ldap_errno')
-            ->will($this->returnValue(500));
-
-        $this->proxy->expects($this->once())
+        $this->phpfunc->expects($this->once())
             ->method('ldap_close')
             ->will($this->returnValue(true));
 
-        $cred = array(
+        $actual = $this->adapter->login(array(
             'username' => 'someusername',
             'password' => 'secretpassword'
+        ));
+
+        $this->assertEquals(
+            array('someusername', array()),
+            $actual
         );
-        $this->adapter->login($cred);
+    }
+
+    public function testBindFailed()
+    {
+        $this->phpfunc->expects($this->once())
+            ->method('ldap_connect')
+            ->with('ldaps://ldap.example.com:636')
+            ->will($this->returnValue(true));
+
+        $this->phpfunc->expects($this->any())
+            ->method('ldap_set_option')
+            ->will($this->returnValue(true));
+
+        $this->phpfunc->expects($this->once())
+            ->method('ldap_bind')
+            ->will($this->returnValue(false));
+
+        $this->phpfunc->expects($this->once())
+            ->method('ldap_errno')
+            ->will($this->returnValue(1));
+
+        $this->phpfunc->expects($this->once())
+            ->method('ldap_error')
+            ->will($this->returnValue('Operations Error'));
+
+        $this->phpfunc->expects($this->once())
+            ->method('ldap_close')
+            ->will($this->returnValue(true));
+
+        $this->setExpectedException('Aura\Auth\Exception\BindFailed');
+        $this->adapter->login(array(
+            'username' => 'someusername',
+            'password' => 'secretpassword'
+        ));
     }
 }

--- a/tests/src/Adapter/LdapAdapterTest.php
+++ b/tests/src/Adapter/LdapAdapterTest.php
@@ -21,8 +21,7 @@ class LdapAdapterTest extends \PHPUnit_Framework_TestCase
                 'ldap_close',
                 'ldap_errno',
                 'ldap_error'
-            ),
-            array()
+            )
         );
 
         $this->adapter = new LdapAdapter(
@@ -41,22 +40,7 @@ class LdapAdapterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testLoginConnectionFailed()
-    {
-        $input = array(
-            'username' => 'someusername',
-            'password' => 'secretpassword'
-        );
-        $this->phpfunc->expects($this->once())
-            ->method('ldap_connect')
-            ->with('ldaps://ldap.example.com:636')
-            ->will($this->returnValue(false));
-
-        $this->setExpectedException('Aura\Auth\Exception\ConnectionFailed');
-        $this->adapter->login($input);
-    }
-
-    public function testLoginSuccess()
+    public function testLogin()
     {
         $this->phpfunc->expects($this->once())
             ->method('ldap_connect')
@@ -95,7 +79,22 @@ class LdapAdapterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testBindFailed()
+    public function testLogin_connectionFailed()
+    {
+        $input = array(
+            'username' => 'someusername',
+            'password' => 'secretpassword'
+        );
+        $this->phpfunc->expects($this->once())
+            ->method('ldap_connect')
+            ->with('ldaps://ldap.example.com:636')
+            ->will($this->returnValue(false));
+
+        $this->setExpectedException('Aura\Auth\Exception\ConnectionFailed');
+        $this->adapter->login($input);
+    }
+
+    public function testLogin_bindFailed()
     {
         $this->phpfunc->expects($this->once())
             ->method('ldap_connect')

--- a/tests/src/PhpfuncTest.php
+++ b/tests/src/PhpfuncTest.php
@@ -1,20 +1,20 @@
 <?php
 namespace Aura\Auth;
 
-class FunctionProxyTest extends \PHPUnit_Framework_TestCase
+class PhpfuncTest extends \PHPUnit_Framework_TestCase
 {
-    protected $proxy;
+    protected $phpfunc;
 
     protected function setUp()
     {
-        $this->proxy = new FunctionProxy;
+        $this->phpfunc = new Phpfunc;
     }
 
     public function testInstance()
     {
         $this->assertEquals(
             str_replace('Hello', 'Hi', 'Hello Aura'),
-            $this->proxy->str_replace('Hello', 'Hi', 'Hello Aura')
+            $this->phpfunc->str_replace('Hello', 'Hi', 'Hello Aura')
         );
     }
 }


### PR DESCRIPTION
- rename $cred/$credentials to $input, and checkCredentials() to checkInput()
- rename FunctionProxy to Phpfunc, in line with other Aura packages
- add LdapAdapter::escape() to escape username value for binding
- finish first pass at testing IMAP and LDAP adapters
