### PR TITLE
if string is empty it should not use hash algorith

### DIFF
--- a/src/Verifier/PasswordVerifier.php
+++ b/src/Verifier/PasswordVerifier.php
@@ -58,7 +58,7 @@ class PasswordVerifier implements VerifierInterface
      */
     public function verify($plaintext, $hashvalue, array $extra = array())
     {
-        if (is_string($this->algo)) {
+        if (is_string($this->algo) && !empty($this->algo)) {
             return hash($this->algo, $plaintext) === $hashvalue;
         } else {
             return password_verify($plaintext, $hashvalue);


### PR DESCRIPTION
In the di https://github.com/auraphp/Aura.Auth/blob/develop-2/config/Common.php#L98

``` php
$di->params['Aura\Auth\Verifier\PasswordVerifier'] = array(
            'algo' => '',
            'opts' => array()
        );
```

Which is empty, and was still calling the hash.
