### PR TITLE
PdoAdapter ignores custom "username" column

### DIFF
--- a/src/Adapter/PdoAdapter.php
+++ b/src/Adapter/PdoAdapter.php
@@ -253,7 +253,7 @@ class PdoAdapter extends AbstractAdapter
      */
     protected function buildSelectWhere()
     {
-        $where = "username = :username";
+        $where = $this->cols[0] . " = :username";
         if ($this->where) {
             $where .= " AND ({$this->where})";
         }


### PR DESCRIPTION
The SQL statement built to fetch user data is hard-coded to use "username" as a column name - even though the PdoAdapter constructor allows the user to specify some other column name where the "username" value is stored.
