### PR TITLE
Increase query flexibility

### DIFF
--- a/src/Adapter/PdoAdapter.php
+++ b/src/Adapter/PdoAdapter.php
@@ -253,7 +253,7 @@ class PdoAdapter extends AbstractAdapter
      */
     protected function buildSelectWhere()
     {
-        $where = "username = :username";
+        $where = $this->cols[0]." = :username";
         if ($this->where) {
             $where .= " AND ({$this->where})";
         }


### PR DESCRIPTION
PdoAdapter.php has the `username` column name hardcoded into the where clause.  Since the documentation states that the first element in `$cols` must be the username column, I've updated `buildSelectWhere()` to use that name instead.
