### PR TITLE
Typo fix.

### DIFF
--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -36,7 +36,7 @@ interface AdapterInterface
      *
      * Handle logout logic against the storage backend.
      *
-     * @param Auth $auth The authentication obbject to be logged out.
+     * @param Auth $auth The authentication object to be logged out.
      *
      * @param string $status The new authentication status after logout.
      *


### PR DESCRIPTION
A quick fix to a typo I ran across while implementing a custom auth adapter.
