### PR TITLE
Typo fix.

### DIFF
--- a/src/AuthFactory.php
+++ b/src/AuthFactory.php
@@ -275,7 +275,7 @@ class AuthFactory
      *
      * @param string $server An LDAP server string.
      *
-     * @param string $dnformat A distinguised name format string for looking up
+     * @param string $dnformat A distinguished name format string for looking up
      * the username.
      *
      * @param array $options Use these connection options.


### PR DESCRIPTION
A quick fix to a typo I ran across while implementing a custom auth adapter.
