### PR TITLE
Adding an optional array of server vars, to make it possible for auto authentication to occur during basic HTTP auth.

### DIFF
--- a/src/Adapter/HtpasswdAdapter.php
+++ b/src/Adapter/HtpasswdAdapter.php
@@ -81,7 +81,7 @@ class HtpasswdAdapter extends AbstractAdapter
      *
      * @return null
      */
-    public function __construct($file, VerifierInterface $verifier, array $serverVars = [])
+    public function __construct($file, VerifierInterface $verifier, array $serverVars = array())
     {
         $this->file = $file;
         $this->verifier = $verifier;

--- a/tests/unit/src/Adapter/HtpasswdAdapterTest.php
+++ b/tests/unit/src/Adapter/HtpasswdAdapterTest.php
@@ -69,4 +69,19 @@ class HtpasswdAdapterTest extends \PHPUnit_Framework_TestCase
             'password' => '------',
         ));
     }
+
+    public function testUsingServerVarsForLogin() {
+        $serverVars = array(
+            'PHP_AUTH_USER' => 'brandon',
+            'PHP_AUTH_PW' => 'password',
+        );
+
+        $file = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'fake.htpasswd';
+        $adapter = new HtpasswdAdapter($file, new HtpasswdVerifier(), $serverVars);
+
+        list($name, $data) = $adapter->login();
+
+        $this->assertSame('brandon', $name);
+        $this->assertSame(array(), $data);
+    }
 }

--- a/tests/unit/src/fake.htpasswd
+++ b/tests/unit/src/fake.htpasswd
@@ -1,3 +1,4 @@
 boshag:A8fw2.ZQWj8uQ
 pmjones:{SHA}MCdMR5A70brHYzu/CXQxSeurgF8=
 harikt:$apr1$c4b0dz9t$FRDSRse3FWsZidoPAx9g0.
+brandon:$apr1$sf4wl6yj$2lM3DzER6zNmX0NqlAMaj/


### PR DESCRIPTION
This fixes an issue, which is that the user currently has to deal with the $_SERVER variables when doing basic auth. Since basic auth can happen all over the application and the user is rarely redirected to an auth page, this will simplify the process of authenticating a user.

If an application is using http auth, and they receive an anonymous user object, they can automatically attempt to log the user in with the credentials that were supplied by the user. These credentials can be automatically loaded into the verification mechanism, avoiding having to do this in each and every action or controller.
