### PR TITLE
A facade to hide the complexity of auth, resume

### DIFF
--- a/src/AuthFacade.php
+++ b/src/AuthFacade.php
@@ -1,0 +1,76 @@
+<?php
+namespace Aura\Auth;
+
+use Aura\Auth\Adapter\AdapterInterface;
+
+class AuthFacade
+{
+    private $auth;
+
+    private $auth_factory;
+
+    private $resume_service;
+
+    public function __construct(AuthFactory $auth_factory, AdapterInterface $adapter)
+    {
+        $this->auth_factory = $auth_factory;
+        $this->adapter = $adapter;
+    }
+
+    public function login($input)
+    {
+        $login_service = $this->getLoginService();
+        return $login_service->login($this->getAuth(), $input);
+    }
+
+    public function logout()
+    {
+        $logout_service = $this->getLogoutService();
+        return $logout_service->logout($this->getAuth());
+    }
+
+    public function forceLogout()
+    {
+        $logout_service = $this->getLogoutService();
+        return $logout_service->forceLogout($this->getAuth());
+    }
+
+    public function forceLogin($username, $userdata)
+    {
+        $login_service = $this->getLoginService();
+        return $login_service->forceLogin($this->getAuth(), $username, $userdata);
+    }
+
+    public function __call($method, array $params)
+    {
+        $this->getResumeService();
+        return call_user_func_array(array($this->getAuth(), $method), $params);
+    }
+
+    private function getAuth()
+    {
+        if (! $this->auth) {
+            $this->auth = $this->auth_factory->newInstance();
+        }
+        return $this->auth;
+    }
+
+    private function getLoginService()
+    {
+        return $this->auth_factory->newLoginService($this->adapter);
+    }
+
+    private function getLogoutService()
+    {
+        return $this->auth_factory->newLogoutService($this->adapter);
+    }
+
+    private function getResumeService()
+    {
+        // only resume on first call
+        if (! $this->resume_service) {
+            $this->resume_service = $this->auth_factory->newResumeService($this->adapter);
+            $this->resume_service->resume($this->getAuth());
+        }
+    }
+}

--- a/src/AuthFacade.php
+++ b/src/AuthFacade.php
@@ -2,6 +2,7 @@
 namespace Aura\Auth;
 
 use Aura\Auth\Adapter\AdapterInterface;
+use Aura\Auth\Status;
 
 class AuthFacade
 {
@@ -17,28 +18,31 @@ class AuthFacade
         $this->adapter = $adapter;
     }
 
-    public function login($input)
+    public function login(array $input)
     {
         $login_service = $this->getLoginService();
         return $login_service->login($this->getAuth(), $input);
     }
 
-    public function logout()
+    public function logout($status = Status::ANON)
     {
         $logout_service = $this->getLogoutService();
         return $logout_service->logout($this->getAuth());
     }
 
-    public function forceLogout()
+    public function forceLogout($status = Status::ANON)
     {
         $logout_service = $this->getLogoutService();
-        return $logout_service->forceLogout($this->getAuth());
+        return $logout_service->forceLogout($this->getAuth(), $status);
     }
 
-    public function forceLogin($username, $userdata)
-    {
+    public function forceLogin(
+        $name,
+        array $data = array(),
+        $status = Status::VALID
+    ) {
         $login_service = $this->getLoginService();
-        return $login_service->forceLogin($this->getAuth(), $username, $userdata);
+        return $login_service->forceLogin($this->getAuth(), $name, $data, $status);
     }
 
     public function __call($method, array $params)

--- a/tests/unit/src/AuthFacadeTest.php
+++ b/tests/unit/src/AuthFacadeTest.php
@@ -1,0 +1,112 @@
+<?php
+namespace Aura\Auth;
+
+use PDO;
+use Aura\Auth\Verifier\PasswordVerifier;
+
+class AuthFacadeTest extends \PHPUnit_Framework_TestCase
+{
+    private $pdo;
+
+    private $auth_facade;
+
+    protected function setUp()
+    {
+        $auth_factory = new AuthFactory($_COOKIE);
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->buildTable();
+        $adapter = $auth_factory->newPdoAdapter(
+            $this->pdo,
+            new PasswordVerifier('md5'),
+            array('username', 'password', 'active'),
+            'accounts',
+            null
+        );
+        $this->auth_facade = new AuthFacade($auth_factory, $adapter);
+    }
+
+    protected function buildTable()
+    {
+        $stm = "CREATE TABLE accounts (
+            username VARCHAR(255),
+            password VARCHAR(255),
+            active VARCHAR(255)
+        )";
+
+        $this->pdo->query($stm);
+
+        $rows = array(
+            array(
+                'username' => 'boshag',
+                'password' => hash('md5', '123456'),
+                'active'    => 'y',
+            ),
+            array(
+                'username' => 'repeat',
+                'password' => hash('md5', '234567'),
+                'active'    => 'y',
+            ),
+            array(
+                'username' => 'repeat',
+                'password' => hash('md5', '234567'),
+                'active'    => 'n',
+            ),
+        );
+
+        $stm = "INSERT INTO accounts (username, password, active)
+                VALUES (:username, :password, :active)";
+
+        $sth = $this->pdo->prepare($stm);
+
+        foreach ($rows as $row) {
+            $sth->execute($row);
+        }
+    }
+
+    public function testLogin()
+    {
+        $this->assertSame('ANON', $this->auth_facade->getStatus());
+        $this->auth_facade->login(array(
+            'username' => 'boshag',
+            'password' => '123456',
+        ));
+
+        $this->assertSame('VALID', $this->auth_facade->getStatus());
+    }
+
+    public function testLogout()
+    {
+        $this->auth_facade->login(array(
+            'username' => 'boshag',
+            'password' => '123456',
+        ));
+
+        $this->assertSame('VALID', $this->auth_facade->getStatus());
+        $this->auth_facade->logout();
+        $this->assertSame('ANON', $this->auth_facade->getStatus());
+    }
+
+    public function testForceLogout()
+    {
+        $this->auth_facade->login(array(
+            'username' => 'boshag',
+            'password' => '123456',
+        ));
+
+        $this->assertSame('VALID', $this->auth_facade->getStatus());
+        $this->auth_facade->forceLogout();
+        $this->assertSame('ANON', $this->auth_facade->getStatus());
+    }
+
+    public function testForceLogin($username, $userdata)
+    {
+        $this->assertSame('ANON', $this->auth_facade->getStatus());
+        $this->auth_facade->forceLogin(array(
+            'username' => 'boshag',
+            'password' => '123456',
+        ));
+
+        $this->assertSame('VALID', $this->auth_facade->getStatus());
+    }
+}

--- a/tests/unit/src/AuthFacadeTest.php
+++ b/tests/unit/src/AuthFacadeTest.php
@@ -3,6 +3,8 @@ namespace Aura\Auth;
 
 use PDO;
 use Aura\Auth\Verifier\PasswordVerifier;
+use Aura\Auth\Session\FakeSession;
+use Aura\Auth\Session\FakeSegment;
 
 class AuthFacadeTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,7 +14,7 @@ class AuthFacadeTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $auth_factory = new AuthFactory($_COOKIE);
+        $auth_factory = new AuthFactory($_COOKIE, new FakeSession, new FakeSegment);
         $this->pdo = new PDO('sqlite::memory:');
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->buildTable();
@@ -99,13 +101,13 @@ class AuthFacadeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('ANON', $this->auth_facade->getStatus());
     }
 
-    public function testForceLogin($username, $userdata)
+    public function testForceLogin()
     {
         $this->assertSame('ANON', $this->auth_facade->getStatus());
-        $this->auth_facade->forceLogin(array(
-            'username' => 'boshag',
-            'password' => '123456',
-        ));
+        $this->auth_facade->forceLogin(
+            'boshag',
+            array('foo' => 'bar')
+        );
 
         $this->assertSame('VALID', $this->auth_facade->getStatus());
     }


### PR DESCRIPTION
~~@pmjones the test fails.~~

But this is the idea I would like to share.

``` php
$auth_factory = new AuthFactory($_COOKIE);
$adapter = $auth_factory->newPdoAdapter(
    $pdo,
    new PasswordVerifier('md5'),
    array('username', 'password', 'active'),
    'accounts',
    null
);
$auth_facade = new AuthFacade($auth_factory, $adapter);
```

I don't know whether the naming of facade is also nice approach here. But the reason is to make it simple to call.

``` php
$auth_facade->login($input);
$auth_facade->logout();
$auth_facade->getStatus();
```

Thank you.
