### PR TITLE
Don't double-close LDAP resources.

### DIFF
--- a/src/Adapter/LdapAdapter.php
+++ b/src/Adapter/LdapAdapter.php
@@ -148,12 +148,11 @@ class LdapAdapter extends AbstractAdapter
             $error = $this->phpfunc->ldap_errno($conn)
                    . ': '
                    . $this->phpfunc->ldap_error($conn);
-            $this->phpfunc->ldap_close($conn);
+            $this->phpfunc->ldap_unbind($conn);
             throw new Exception\BindFailed($error);
         }
 
         $this->phpfunc->ldap_unbind($conn);
-        $this->phpfunc->ldap_close($conn);
     }
 
     /**

--- a/tests/Adapter/LdapAdapterTest.php
+++ b/tests/Adapter/LdapAdapterTest.php
@@ -18,7 +18,6 @@ class LdapAdapterTest extends \PHPUnit_Framework_TestCase
                 'ldap_bind',
                 'ldap_unbind',
                 'ldap_set_option',
-                'ldap_close',
                 'ldap_errno',
                 'ldap_error'
             )
@@ -62,10 +61,6 @@ class LdapAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->phpfunc->expects($this->once())
             ->method('ldap_unbind')
-            ->will($this->returnValue(true));
-
-        $this->phpfunc->expects($this->once())
-            ->method('ldap_close')
             ->will($this->returnValue(true));
 
         $actual = $this->adapter->login(array(
@@ -118,7 +113,7 @@ class LdapAdapterTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('Operations Error'));
 
         $this->phpfunc->expects($this->once())
-            ->method('ldap_close')
+            ->method('ldap_unbind')
             ->will($this->returnValue(true));
 
         $this->setExpectedException('Aura\Auth\Exception\BindFailed');


### PR DESCRIPTION
`ldap_close` [is just an alias](http://php.net/manual/en/function.ldap-close.php) for `ldap_unbind`. Remove instance where we call both `ldap_unbind` and `ldap_close`, and use `ldap_unbind` in place of `ldap_close` where only one is called.
