### PR TITLE
Fix 2 spelling errors

### DIFF
--- a/config/Common.php
+++ b/config/Common.php
@@ -99,8 +99,8 @@ class Common extends Config
          * Aura\Auth\Session\Timer
          */
         $di->params['Aura\Auth\Session\Timer'] = array(
-            'ini_gc_maxliftime' => ini_get('session.gc_maxlifetime'),
-            'ini_cookie_liftime' => ini_get('session.cookie_lifetime'),
+            'ini_gc_maxlifetime' => ini_get('session.gc_maxlifetime'),
+            'ini_cookie_lifetime' => ini_get('session.cookie_lifetime'),
             'idle_ttl' => 1440,
             'expire_ttl' => 14400,
         );


### PR DESCRIPTION
Fix 2 bugs which were making me crazy in my Web 2 application.  ;-)

By the way, the PHP default value (including in shipped php.ini files) for idle timeout of 1440 seconds is wholly arbitrary and most likely a mistake.  The original PHP sessions used minutes for the timeout value, and 1440 minutes was exactly 1 day (60 \* 24).  A 24 minute idle session timeout default is slightly crazy.
