### PR TITLE
Correctly skip PDO tests if required pdo_sqlite extension not enabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: php
 php:
   - 5.3
@@ -6,11 +5,12 @@ php:
   - 5.5
   - 5.6
   - 7
+  - 7.1
 before_script:
   - composer self-update
   - composer install
 script:
-  - phpunit --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --coverage-clover=coverage.clover
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# CHANGELOG 
+
+## 2.0.0
+
+First stable 2.0 release.
+
+- (FIX) Correct AuthFactory namespace, and add test.
+
+- (DOC) Additions and corrections in README.
+
+- (FIX) Add missing Status in AdapterInterface.
+
+## 2.0.0-beta2
+
+- DOC: Updated README and docblocks.
+
+- CHG: PdoAdapter::buildSelectWhere() now honors the custom column name provided by the user.
+
+- CHG: Turn off auto-resolution in Container tests
+
+## 2.0.0-beta1
+
+Initial 2.0.0 beta release.
+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,0 @@
-First stable 2.0 release.
-
-- (FIX) Correct AuthFactory namespace, and add test.
-
-- (DOC) Additions and corrections in README.
-
-- (FIX) Add missing Status in AdapterInterface.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alternatively, [download a release](https://github.com/auraphp/Aura.Auth/release
 [![Code Coverage](https://scrutinizer-ci.com/g/auraphp/Aura.Auth/badges/coverage.png?b=develop-2)](https://scrutinizer-ci.com/g/auraphp/Aura.Auth/?branch=develop-2)
 [![Build Status](https://travis-ci.org/auraphp/Aura.Auth.png?branch=develop-2)](https://travis-ci.org/auraphp/Aura.Auth)
 
-To run the unit tests at the command line, issue `composer install` and then `phpunit` at the package root. This requires [Composer](http://getcomposer.org/) to be available as `composer`, and [PHPUnit](http://phpunit.de/manual/) to be available as `phpunit`.
+To run the unit tests at the command line, issue `composer install` and then `vendor/bin/phpunit` at the package root. This requires [Composer](http://getcomposer.org/) to be available as `composer`.
 
 This library attempts to comply with [PSR-1][], [PSR-2][], and [PSR-4][]. If
 you notice compliance oversights, please send a patch via pull request.

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,20 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "aura/di": "~2.0",
+        "phpunit/phpunit": "~5.7 || ~4.8"
+    },
     "autoload": {
         "psr-4": {
             "Aura\\Auth\\": "src/",
             "Aura\\Auth\\_Config\\": "config/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Aura\\Auth\\": "tests/",
+            "Aura\\Di\\": "vendor/aura/di/tests/"
         }
     },
     "extra": {
@@ -36,14 +46,5 @@
         "ext/ldap": "For LDAP integration.",
         "ext/imap": "For IMAP/POP/NNTP integration.",
         "ircmaxell/password-compat": "Provides password_verify() for PHP versions earlier than 5.5"
-    },
-    "require-dev": {
-        "aura/di": "~2.0"
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Aura\\Auth\\": "tests/",
-            "Aura\\Di\\": "vendor/aura/di/tests/"
-        }
     }
 }

--- a/tests/Adapter/ImapAdapterTest.php
+++ b/tests/Adapter/ImapAdapterTest.php
@@ -11,13 +11,12 @@ class ImapAdapterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->phpfunc = $this->getMock(
-            'Aura\Auth\Phpfunc',
-            array(
-                'imap_open',
-                'imap_close',
-            )
-        );
+        $this->phpfunc = $this->getMockBuilder('Aura\Auth\Phpfunc')
+             ->setMethods(array(
+                 'imap_open',
+                 'imap_close',
+             ))
+             ->getMock();
 
         $this->adapter = new ImapAdapter(
             $this->phpfunc,

--- a/tests/Adapter/LdapAdapterTest.php
+++ b/tests/Adapter/LdapAdapterTest.php
@@ -11,17 +11,16 @@ class LdapAdapterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->phpfunc = $this->getMock(
-            'Aura\Auth\Phpfunc',
-            array(
-                'ldap_connect',
-                'ldap_bind',
-                'ldap_unbind',
-                'ldap_set_option',
-                'ldap_errno',
-                'ldap_error'
-            )
-        );
+        $this->phpfunc = $this->getMockBuilder('Aura\Auth\Phpfunc')
+             ->setMethods(array(
+                 'ldap_connect',
+                 'ldap_bind',
+                 'ldap_unbind',
+                 'ldap_set_option',
+                 'ldap_errno',
+                 'ldap_error'
+             ))
+             ->getMock();        
 
         $this->adapter = new LdapAdapter(
             $this->phpfunc,

--- a/tests/Adapter/PdoAdapterTest.php
+++ b/tests/Adapter/PdoAdapterTest.php
@@ -12,6 +12,10 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        if (false === extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped("Cannot test this adapter with pdo_sqlite extension disabled.");
+        }
+
         $this->pdo = new PDO('sqlite::memory:');
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->buildTable();

--- a/tests/AuthFactoryTest.php
+++ b/tests/AuthFactoryTest.php
@@ -29,6 +29,10 @@ class AuthFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testNewPdoAdapter_passwordVerifier()
     {
+        if (false === extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped("Cannot test this adapter with pdo_sqlite extension disabled.");
+        }
+
         $pdo = new PDO('sqlite::memory:');
         $adapter = $this->factory->newPdoAdapter(
             $pdo,
@@ -44,6 +48,10 @@ class AuthFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testNewPdoAdapter_customVerifier()
     {
+        if (false === extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped("Cannot test this adapter with pdo_sqlite extension disabled.");
+        }
+
         $pdo = new PDO('sqlite::memory:');
         $adapter = $this->factory->newPdoAdapter(
             $pdo,


### PR DESCRIPTION
Fixes #78 .