### PR TITLE
New 4.x branch for modern PHP and PHPUnit usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,13 @@ language: php
 matrix:
     include:
         - os: linux
-          dist: precise
+          dist: trusty
           sudo: false
-          php: 5.3
-        - os: linux
-          dist: precise
-          sudo: false
-          php: 5.4
-        - os: linux
-          dist: precise
-          sudo: false
-          php: 5.5
-        - os: linux
-          dist: precise
-          sudo: false
-          php: 5.6
-          env:
-            - TEST_COVERAGE=true
+          php: 7.2
         - os: linux
           dist: trusty
           sudo: false
-          php: 7
-        - os: linux
-          dist: trusty
-          sudo: false
-          php: 7.1
-        - os: linux
-          dist: trusty
-          sudo: false
-          php: hhvm
+          php: 7.3
         - os: linux
           dist: trusty
           sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ matrix:
           dist: trusty
           sudo: false
           php: 7.3
-        - os: linux
-          dist: trusty
-          sudo: false
-          php: nightly
 
 before_script:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Note that the purpose of this package is only to authenticate user credentials. 
 
 ### Installation
 
-This library requires PHP 5.5 or later, and has no userland dependencies.  (As a special consideration, this library is compatible with PHP 5.3 and 5.4 when the [ircmaxell/password-compat](https://github.com/ircmaxell/password_compat) package is installed.)
+This library requires PHP 7.2 or later, and has no userland dependencies.
 
 It is installable and autoloadable via Composer as [aura/auth](https://packagist.org/packages/aura/auth).
 

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
 
     "minimum-stability": "dev",
     "require-dev": {
+        "acclimate/container": "^2",
         "aura/di": "~4.0",
         "phpunit/phpunit": "~7"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.2.0"
     },
     "autoload": {
         "psr-4": {
@@ -32,9 +32,11 @@
             }
         }
     },
+
+    "minimum-stability": "dev",
     "require-dev": {
-        "aura/di": "~2.0",
-        "phpunit/phpunit": "~5.7 || ~4.8"
+        "aura/di": "~4.0",
+        "phpunit/phpunit": "~7"
     },
     "autoload-dev": {
         "psr-4": {
@@ -44,7 +46,6 @@
     },
     "suggest": {
         "ext/ldap": "For LDAP integration.",
-        "ext/imap": "For IMAP/POP/NNTP integration.",
-        "ircmaxell/password-compat": "Provides password_verify() for PHP versions earlier than 5.5"
+        "ext/imap": "For IMAP/POP/NNTP integration."
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,4 +4,7 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <ini name="session.gc_maxlifetime" value="86400"/>
+    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit bootstrap="./phpunit.php">
     <testsuites>
-        <testsuite>
+        <testsuite name="tests">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>

--- a/src/AuthFactory.php
+++ b/src/AuthFactory.php
@@ -134,8 +134,8 @@ class AuthFactory
      */
     public function newResumeService(
         AdapterInterface $adapter = null,
-        $idle_ttl = 1440,
-        $expire_ttl = 14400
+        $idle_ttl = 3600,               // 1 hour
+        $expire_ttl = 86400             // 24 hours
     ) {
 
         $adapter = $this->fixAdapter($adapter);

--- a/src/Session/Timer.php
+++ b/src/Session/Timer.php
@@ -43,7 +43,7 @@ class Timer
      * @var int
      *
      */
-    protected $idle_ttl = 1440;
+    protected $idle_ttl = 3600;             // 1 hour
 
     /**
      *
@@ -52,7 +52,7 @@ class Timer
      * @var int
      *
      */
-    protected $expire_ttl = 14400;
+    protected $expire_ttl = 86400;          // 24 hours
 
     /**
      *
@@ -68,10 +68,10 @@ class Timer
      *
      */
     public function __construct(
-        $ini_gc_maxlifetime = 1440,
+        $ini_gc_maxlifetime = 86401,        // 24 hours plus 1 second
         $ini_cookie_lifetime = 0,
-        $idle_ttl = 1440,
-        $expire_ttl = 14400
+        $idle_ttl = 3600,                   // 1 hour
+        $expire_ttl = 86400                 // 24 hours
     ) {
         $this->ini_gc_maxlifetime = $ini_gc_maxlifetime;
         $this->ini_cookie_lifetime = $ini_cookie_lifetime;
@@ -94,7 +94,7 @@ class Timer
     public function setIdleTtl($idle_ttl)
     {
         if ($this->ini_gc_maxlifetime < $idle_ttl) {
-            throw new Exception('session.gc_maxlifetime less than idle time');
+            throw new Exception("session.gc_maxlifetime {$this->ini_gc_maxlifetime} less than idle time $idle_ttl");
         }
         $this->idle_ttl = $idle_ttl;
     }

--- a/tests/Adapter/HtpasswdAdapterTest.php
+++ b/tests/Adapter/HtpasswdAdapterTest.php
@@ -3,7 +3,7 @@ namespace Aura\Auth\Adapter;
 
 use Aura\Auth\Verifier\HtpasswdVerifier;
 
-class HtpasswdAdapterTest extends \PHPUnit_Framework_TestCase
+class HtpasswdAdapterTest extends \PHPUnit\Framework\TestCase
 {
     protected $adapter;
 

--- a/tests/Adapter/HtpasswdAdapterTest.php
+++ b/tests/Adapter/HtpasswdAdapterTest.php
@@ -21,7 +21,7 @@ class HtpasswdAdapterTest extends \PHPUnit\Framework\TestCase
     public function testLogin_fileNotReadable()
     {
         $this->setAdapter('no-such-file');
-        $this->setExpectedException('Aura\Auth\Exception\FileNotReadable');
+        $this->expectException('Aura\Auth\Exception\FileNotReadable');
         $this->adapter->login(array(
             'username' => 'boshag',
             'password' => '123456',
@@ -40,13 +40,13 @@ class HtpasswdAdapterTest extends \PHPUnit\Framework\TestCase
 
     public function testLogin_usernameMissing()
     {
-        $this->setExpectedException('Aura\Auth\Exception\UsernameMissing');
+        $this->expectException('Aura\Auth\Exception\UsernameMissing');
         $this->adapter->login(array());
     }
 
     public function testLogin_passwordMissing()
     {
-        $this->setExpectedException('Aura\Auth\Exception\PasswordMissing');
+        $this->expectException('Aura\Auth\Exception\PasswordMissing');
         $this->adapter->login(array(
             'username' => 'boshag',
         ));
@@ -54,7 +54,7 @@ class HtpasswdAdapterTest extends \PHPUnit\Framework\TestCase
 
     public function testLogin_usernameNotFound()
     {
-        $this->setExpectedException('Aura\Auth\Exception\UsernameNotFound');
+        $this->expectException('Aura\Auth\Exception\UsernameNotFound');
         $this->adapter->login(array(
             'username' => 'nouser',
             'password' => 'nopass',
@@ -63,7 +63,7 @@ class HtpasswdAdapterTest extends \PHPUnit\Framework\TestCase
 
     public function testLogin_passwordIncorrect()
     {
-        $this->setExpectedException('Aura\Auth\Exception\PasswordIncorrect');
+        $this->expectException('Aura\Auth\Exception\PasswordIncorrect');
         $this->adapter->login(array(
             'username' => 'boshag',
             'password' => '------',

--- a/tests/Adapter/ImapAdapterTest.php
+++ b/tests/Adapter/ImapAdapterTest.php
@@ -63,7 +63,7 @@ class ImapAdapterTest extends \PHPUnit\Framework\TestCase
             ->with('{mailbox.example.com:143/imap/secure}')
             ->will($this->returnValue(false));
 
-        $this->setExpectedException('Aura\Auth\Exception\ConnectionFailed');
+        $this->expectException('Aura\Auth\Exception\ConnectionFailed');
         $this->adapter->login(array(
             'username' => 'someusername',
             'password' => 'secretpassword'

--- a/tests/Adapter/ImapAdapterTest.php
+++ b/tests/Adapter/ImapAdapterTest.php
@@ -3,7 +3,7 @@ namespace Aura\Auth\Adapter;
 
 use Aura\Auth\Phpfunc;
 
-class ImapAdapterTest extends \PHPUnit_Framework_TestCase
+class ImapAdapterTest extends \PHPUnit\Framework\TestCase
 {
     protected $phpfunc;
 

--- a/tests/Adapter/LdapAdapterTest.php
+++ b/tests/Adapter/LdapAdapterTest.php
@@ -84,7 +84,7 @@ class LdapAdapterTest extends \PHPUnit\Framework\TestCase
             ->with('ldaps://ldap.example.com:636')
             ->will($this->returnValue(false));
 
-        $this->setExpectedException('Aura\Auth\Exception\ConnectionFailed');
+        $this->expectException('Aura\Auth\Exception\ConnectionFailed');
         $this->adapter->login($input);
     }
 
@@ -115,7 +115,7 @@ class LdapAdapterTest extends \PHPUnit\Framework\TestCase
             ->method('ldap_unbind')
             ->will($this->returnValue(true));
 
-        $this->setExpectedException('Aura\Auth\Exception\BindFailed');
+        $this->expectException('Aura\Auth\Exception\BindFailed');
         $this->adapter->login(array(
             'username' => 'someusername',
             'password' => 'secretpassword'

--- a/tests/Adapter/LdapAdapterTest.php
+++ b/tests/Adapter/LdapAdapterTest.php
@@ -3,7 +3,7 @@ namespace Aura\Auth\Adapter;
 
 use Aura\Auth\Phpfunc;
 
-class LdapAdapterTest extends \PHPUnit_Framework_TestCase
+class LdapAdapterTest extends \PHPUnit\Framework\TestCase
 {
     protected $adapter;
 

--- a/tests/Adapter/NullAdapterTest.php
+++ b/tests/Adapter/NullAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Auth\Adapter;
 
-class NullAdapterTest extends \PHPUnit_Framework_TestCase
+class NullAdapterTest extends \PHPUnit\Framework\TestCase
 {
     protected $adapter;
 

--- a/tests/Adapter/PdoAdapterTest.php
+++ b/tests/Adapter/PdoAdapterTest.php
@@ -4,7 +4,7 @@ namespace Aura\Auth\Adapter;
 use PDO;
 use Aura\Auth\Verifier\PasswordVerifier;
 
-class PdoAdapterTest extends \PHPUnit_Framework_TestCase
+class PdoAdapterTest extends \PHPUnit\Framework\TestCase
 {
     protected $adapter;
 

--- a/tests/Adapter/PdoAdapterTest.php
+++ b/tests/Adapter/PdoAdapterTest.php
@@ -73,7 +73,7 @@ class PdoAdapterTest extends \PHPUnit\Framework\TestCase
 
     public function test_usernameColumnNotSpecified()
     {
-        $this->setExpectedException('Aura\Auth\Exception\UsernameColumnNotSpecified');
+        $this->expectException('Aura\Auth\Exception\UsernameColumnNotSpecified');
         $this->adapter = new PdoAdapter(
             $this->pdo,
             new PasswordVerifier('md5'),
@@ -84,7 +84,7 @@ class PdoAdapterTest extends \PHPUnit\Framework\TestCase
 
     public function test_passwordColumnNotSpecified()
     {
-        $this->setExpectedException('Aura\Auth\Exception\PasswordColumnNotSpecified');
+        $this->expectException('Aura\Auth\Exception\PasswordColumnNotSpecified');
         $this->adapter = new PdoAdapter(
             $this->pdo,
             new PasswordVerifier('md5'),
@@ -106,13 +106,13 @@ class PdoAdapterTest extends \PHPUnit\Framework\TestCase
 
     public function testLogin_usernameMissing()
     {
-        $this->setExpectedException('Aura\Auth\Exception\UsernameMissing');
+        $this->expectException('Aura\Auth\Exception\UsernameMissing');
         $this->adapter->login(array());
     }
 
     public function testLogin_passwordMissing()
     {
-        $this->setExpectedException('Aura\Auth\Exception\PasswordMissing');
+        $this->expectException('Aura\Auth\Exception\PasswordMissing');
         $this->adapter->login(array(
             'username' => 'boshag',
         ));
@@ -120,7 +120,7 @@ class PdoAdapterTest extends \PHPUnit\Framework\TestCase
 
     public function testLogin_usernameNotFound()
     {
-        $this->setExpectedException('Aura\Auth\Exception\UsernameNotFound');
+        $this->expectException('Aura\Auth\Exception\UsernameNotFound');
         $this->adapter->login(array(
             'username' => 'missing',
             'password' => '------',
@@ -129,7 +129,7 @@ class PdoAdapterTest extends \PHPUnit\Framework\TestCase
 
     public function testLogin_passwordIncorrect()
     {
-        $this->setExpectedException('Aura\Auth\Exception\PasswordIncorrect');
+        $this->expectException('Aura\Auth\Exception\PasswordIncorrect');
         $this->adapter->login(array(
             'username' => 'boshag',
             'password' => '------',
@@ -138,7 +138,7 @@ class PdoAdapterTest extends \PHPUnit\Framework\TestCase
 
     public function testLogin_multipleMatches()
     {
-        $this->setExpectedException('Aura\Auth\Exception\MultipleMatches');
+        $this->expectException('Aura\Auth\Exception\MultipleMatches');
         $this->adapter->login(array(
             'username' => 'repeat',
             'password' => '234567',

--- a/tests/AuthFactoryTest.php
+++ b/tests/AuthFactoryTest.php
@@ -6,7 +6,7 @@ use Aura\Auth\Session\Session;
 use Aura\Auth\Session\Segment;
 use Aura\Auth\Verifier\FakeVerifier;
 
-class AuthFactoryTest extends \PHPUnit_Framework_TestCase
+class AuthFactoryTest extends \PHPUnit\Framework\TestCase
 {
     protected $factory;
 

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -4,7 +4,7 @@ namespace Aura\Auth;
 use Aura\Auth\Session\FakeSegment;
 use Aura\Auth\Status;
 
-class AuthTest extends \PHPUnit_Framework_TestCase
+class AuthTest extends \PHPUnit\Framework\TestCase
 {
     protected $auth;
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Auth;
 
-use Aura\Di\_Config\AbstractContainerTest;
+use Aura\Di\ContainerTest as AbstractContainerTest;
 
 class ContainerTest extends AbstractContainerTest
 {

--- a/tests/PhpfuncTest.php
+++ b/tests/PhpfuncTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Auth;
 
-class PhpfuncTest extends \PHPUnit_Framework_TestCase
+class PhpfuncTest extends \PHPUnit\Framework\TestCase
 {
     protected $phpfunc;
 

--- a/tests/Service/LoginServiceTest.php
+++ b/tests/Service/LoginServiceTest.php
@@ -8,7 +8,7 @@ use Aura\Auth\Session\Timer;
 use Aura\Auth\Auth;
 use Aura\Auth\Status;
 
-class LoginServiceTest extends \PHPUnit_Framework_TestCase
+class LoginServiceTest extends \PHPUnit\Framework\TestCase
 {
     protected $segment;
 

--- a/tests/Service/LogoutServiceTest.php
+++ b/tests/Service/LogoutServiceTest.php
@@ -8,7 +8,7 @@ use Aura\Auth\Session\Timer;
 use Aura\Auth\Auth;
 use Aura\Auth\Status;
 
-class LogoutServiceTest extends \PHPUnit_Framework_TestCase
+class LogoutServiceTest extends \PHPUnit\Framework\TestCase
 {
     protected $session;
 

--- a/tests/Service/ResumeServiceTest.php
+++ b/tests/Service/ResumeServiceTest.php
@@ -8,7 +8,7 @@ use Aura\Auth\Session\Timer;
 use Aura\Auth\Auth;
 use Aura\Auth\Status;
 
-class ResumeServiceTest extends \PHPUnit_Framework_TestCase
+class ResumeServiceTest extends \PHPUnit\Framework\TestCase
 {
     protected $segment;
 

--- a/tests/Service/ResumeServiceTest.php
+++ b/tests/Service/ResumeServiceTest.php
@@ -31,7 +31,7 @@ class ResumeServiceTest extends \PHPUnit_Framework_TestCase
         $this->segment = new FakeSegment;
         $this->session = new FakeSession;
         $this->adapter = new FakeAdapter;
-        $this->timer = new Timer(1440, 14400);
+        $this->timer = new Timer(3600, 86400);
 
         $this->auth = new Auth($this->segment);
 
@@ -79,7 +79,7 @@ class ResumeServiceTest extends \PHPUnit_Framework_TestCase
         $this->login_service->forceLogin($this->auth, 'boshag');
         $this->assertTrue($this->auth->isValid());
 
-        $this->auth->setLastActive(time() - 1441);
+        $this->auth->setLastActive(time() - 3601);
 
         $this->resume_service->resume($this->auth);
         $this->assertTrue($this->auth->isIdle());
@@ -92,7 +92,7 @@ class ResumeServiceTest extends \PHPUnit_Framework_TestCase
         $this->login_service->forceLogin($this->auth, 'boshag');
         $this->assertTrue($this->auth->isValid());
 
-        $this->auth->setFirstActive(time() - 14441);
+        $this->auth->setFirstActive(time() - 86401);
 
         $this->resume_service->resume($this->auth);
         $this->assertTrue($this->auth->isExpired());

--- a/tests/Session/NullSegmentTest.php
+++ b/tests/Session/NullSegmentTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Auth\Session;
 
-class NullSegmentTest extends \PHPUnit_Framework_TestCase
+class NullSegmentTest extends \PHPUnit\Framework\TestCase
 {
     protected $segment;
 

--- a/tests/Session/NullSessionTest.php
+++ b/tests/Session/NullSessionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Auth\Session;
 
-class NullSessionTest extends \PHPUnit_Framework_TestCase
+class NullSessionTest extends \PHPUnit\Framework\TestCase
 {
     protected $session;
 

--- a/tests/Session/SegmentTest.php
+++ b/tests/Session/SegmentTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Auth\Session;
 
-class SegmentTest extends \PHPUnit_Framework_TestCase
+class SegmentTest extends \PHPUnit\Framework\TestCase
 {
     protected $segment;
 

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -4,7 +4,7 @@ namespace Aura\Auth\Session;
 /**
  * @runTestsInSeparateProcesses
  */
-class SessionTest extends \PHPUnit_Framework_TestCase
+class SessionTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/Session/TimerTest.php
+++ b/tests/Session/TimerTest.php
@@ -47,13 +47,13 @@ class TimerTest extends \PHPUnit\Framework\TestCase
 
     public function testSetIdleTtl_bad()
     {
-        $this->setExpectedException('Aura\Auth\Exception');
+        $this->expectException('Aura\Auth\Exception');
         $this->timer->setIdleTtl(3601);
     }
 
     public function testSetExpireTtl_bad()
     {
-        $this->setExpectedException('Aura\Auth\Exception');
+        $this->expectException('Aura\Auth\Exception');
         $this->timer->setExpireTtl(86401);
     }
 }

--- a/tests/Session/TimerTest.php
+++ b/tests/Session/TimerTest.php
@@ -3,7 +3,7 @@ namespace Aura\Auth\Session;
 
 use Aura\Auth\Status;
 
-class TimerTest extends \PHPUnit_Framework_TestCase
+class TimerTest extends \PHPUnit\Framework\TestCase
 {
     protected $timer;
 

--- a/tests/Session/TimerTest.php
+++ b/tests/Session/TimerTest.php
@@ -9,32 +9,32 @@ class TimerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->timer = new Timer(1440, 14400);
+        $this->timer = new Timer(3600, 86400);
     }
 
     public function testHasExpired()
     {
         $this->assertFalse($this->timer->hasExpired(time()));
-        $this->assertTrue($this->timer->hasExpired(time() - 14441));
+        $this->assertTrue($this->timer->hasExpired(time() - 86401));
     }
 
     public function testHasIdled()
     {
         $this->assertFalse($this->timer->hasIdled(time()));
-        $this->assertTrue($this->timer->hasIdled(time() - 1441));
+        $this->assertTrue($this->timer->hasIdled(time() - 3601));
     }
 
     public function testGetTimeoutStatus()
     {
         $actual = $this->timer->getTimeoutStatus(
-            time() - 14441,
+            time() - 86401,
             time()
         );
         $this->assertSame(Status::EXPIRED, $actual);
 
         $actual = $this->timer->getTimeoutStatus(
-            time() - 1442,
-            time() - 1441
+            time() - 3602,
+            time() - 3601
         );
 
         $this->assertSame(Status::IDLE, $actual);
@@ -48,12 +48,12 @@ class TimerTest extends \PHPUnit_Framework_TestCase
     public function testSetIdleTtl_bad()
     {
         $this->setExpectedException('Aura\Auth\Exception');
-        $this->timer->setIdleTtl(1441);
+        $this->timer->setIdleTtl(3601);
     }
 
     public function testSetExpireTtl_bad()
     {
         $this->setExpectedException('Aura\Auth\Exception');
-        $this->timer->setExpireTtl(14441);
+        $this->timer->setExpireTtl(86401);
     }
 }

--- a/tests/Verifier/HtpasswdVerifierTest.php
+++ b/tests/Verifier/HtpasswdVerifierTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Auth\Verifier;
 
-class HtpasswdVerifierTest extends \PHPUnit_Framework_TestCase
+class HtpasswdVerifierTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Verifier/PasswordVerifierTest.php
+++ b/tests/Verifier/PasswordVerifierTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Auth\Verifier;
 
-class PasswordVerifierTest extends \PHPUnit_Framework_TestCase
+class PasswordVerifierTest extends \PHPUnit\Framework\TestCase
 {
     public function testBcrypt()
     {


### PR DESCRIPTION
I've forked Aura.Auth and created a new branch called 4.x to update the Composer dependencies and the unit test code to require and be compatible with PHP 7.2+ and PHPUnit 7+ so that other packages which use Aura.Auth can continue to use it.

You might be able to merge this PR directly, but am unsure how GitHub handles merging new branches.  I started with 2.x, branched it to 4.x as 3.x seemed to be in a half-baked state.  Will GitHub create a 4.x branch if this PR is merged?  I don't know.  If yes, it's good to go.  If not, Aura.Auth will probably need to create a 4.x branch and I can resubmit this PR against it.

Either way, I *need* modern, up-to-date Aura/Auth, Auth/Di (thank you @frederikbosch for making that so), and Aura/Payload (as well as Relay, Radar, Arbiter, etc. -- I'll handle Radar myself soon).