### PR TITLE
Ädd optional user-loader seam for Remember-Me

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,16 +7,6 @@
 - OIDC (`id_token`) handling and token refresh. Deferred: larger surface; leave
   to the client for now.
 
-## Remember Me — Follow-ups
-
-- Remember-Me stores a snapshot of user data server-side in the token storage
-  row (the cookie carries only the `selector:validator`) and replays that
-  snapshot on resume. Add an optional user-loader seam so resume can re-fetch
-  fresh user details from the source (picks up admin-side changes to
-  roles/email/etc.). Cf.
-  <https://github.com/craigrodway/LoginPersist/blob/master/LoginPersist.module>
-  and other implementations for ideas.
-
 ## Verifiers
 
 Build an HttpDigestVerifier based on <http://php.net/manual/en/features.http-auth.php> and/or <http://evertpot.com/223/>.

--- a/docs/remember-me.md
+++ b/docs/remember-me.md
@@ -69,6 +69,7 @@ $remember_service = $auth_factory->newRememberService($storage, array(
     'samesite' => 'Lax',        // SameSite policy (default 'Lax')
     'path'     => '/',
     'domain'   => '',
+    // 'user_loader' => $fn,    // optional; see "Refreshing User Data" below
 ));
 
 $login_service  = $auth_factory->newLoginService($adapter, $remember_service);
@@ -113,6 +114,43 @@ Once wired, the feature works through the call sites you already have:
   $logout_service->logout($auth);
   ?>
   ```
+
+## Refreshing User Data On Resume
+
+By default, `resume()` restores the user data **snapshot** that was captured in
+storage when the token was issued. If an administrator later changes the user
+(new roles, a changed email, a disabled account), a remembered session keeps
+serving the stale copy until the next full credential login.
+
+To pick up such changes, pass an optional `user_loader` callable. It receives the
+remembered user name and returns the fresh user data on each resume:
+
+```php
+<?php
+$remember_service = $auth_factory->newRememberService($storage, array(
+    'user_loader' => function ($username) use ($pdo) {
+        $stm = $pdo->prepare('SELECT * FROM users WHERE username = :username');
+        $stm->execute(array('username' => $username));
+        $user = $stm->fetch(PDO::FETCH_ASSOC);
+
+        // return null to reject: the user no longer exists or is disabled,
+        // which revokes the token and leaves the visitor anonymous.
+        if (! $user || ! $user['is_active']) {
+            return null;
+        }
+
+        // otherwise return the fresh user data to restore
+        unset($user['password']);
+        return $user;
+    },
+));
+?>
+```
+
+The loader's return value is used in place of the stored snapshot; the remembered
+user name is preserved as the identity. Returning `null` treats the user as gone:
+the token is deleted from storage, the cookie is cleared, and `resume()` returns
+`false` (exactly like an expired or tampered token).
 
 ## Log Out Everywhere
 

--- a/docs/remember-me.md
+++ b/docs/remember-me.md
@@ -148,7 +148,7 @@ $remember_service = $auth_factory->newRememberService($storage, array(
 ```
 
 The loader's return value is used in place of the stored snapshot; the remembered
-user name is preserved as the identity. Returning `null` treats the user as gone:
+username is preserved as the identity. Returning `null` treats the user as gone:
 the token is deleted from storage, the cookie is cleared, and `resume()` returns
 `false` (exactly like an expired or tampered token).
 

--- a/src/AuthFactory.php
+++ b/src/AuthFactory.php
@@ -196,8 +196,9 @@ class AuthFactory
      *
      * @param array $options Options for the service and cookie: `name` (cookie
      * name, default "remember"), `ttl` (token lifetime in seconds, default 30
-     * days), and cookie params `path`, `domain`, `secure`, `httponly`,
-     * `samesite`.
+     * days), `user_loader` (an optional `fn(string $username): ?array` to
+     * re-fetch fresh user data on resume), and cookie params `path`, `domain`,
+     * `secure`, `httponly`, `samesite`.
      *
      * @return RememberService
      *
@@ -209,6 +210,7 @@ class AuthFactory
         $phpfunc = new Phpfunc;
         $name = isset($options['name']) ? $options['name'] : 'remember';
         $ttl = isset($options['ttl']) ? $options['ttl'] : 2592000; // 30 days
+        $user_loader = isset($options['user_loader']) ? $options['user_loader'] : null;
 
         return new Remember\RememberService(
             $storage,
@@ -216,7 +218,8 @@ class AuthFactory
             new Remember\Token($phpfunc),
             new Remember\Cookie($phpfunc, $this->cookie, $options),
             $name,
-            $ttl
+            $ttl,
+            $user_loader
         );
     }
 

--- a/src/Remember/RememberService.php
+++ b/src/Remember/RememberService.php
@@ -17,6 +17,12 @@ use Aura\Session_Interface\SessionInterface;
  * "Remember me" handler using the split-token (selector : validator) scheme
  * with server-side storage and per-use token rotation.
  *
+ * By default, resume() restores the user data snapshot captured in storage when
+ * the token was issued. An optional user-loader callable may be supplied to
+ * instead re-fetch fresh user data from the application's source of truth on
+ * every resume, so that admin-side changes (roles, email, a disabled account)
+ * take effect without waiting for a full credential login.
+ *
  * @package Aura.Auth
  *
  */
@@ -78,6 +84,17 @@ class RememberService
 
     /**
      *
+     * An optional `fn(string $username): ?array` used on resume to re-fetch
+     * fresh user data from the source of truth. Returning null signals that the
+     * user no longer exists (or is disabled), which revokes the token.
+     *
+     * @var callable|null
+     *
+     */
+    protected $user_loader;
+
+    /**
+     *
      * Constructor.
      *
      * @param RememberStorageInterface $storage Server-side token storage.
@@ -92,6 +109,10 @@ class RememberService
      *
      * @param int $ttl The token lifetime in seconds (default 30 days).
      *
+     * @param callable $user_loader An optional `fn(string $username): ?array`
+     * to re-fetch fresh user data on resume; null (the default) replays the
+     * stored snapshot instead.
+     *
      */
     public function __construct(
         RememberStorageInterface $storage,
@@ -99,7 +120,8 @@ class RememberService
         Token $token,
         Cookie $cookie,
         $name = 'remember',
-        $ttl = 2592000
+        $ttl = 2592000,
+        ?callable $user_loader = null
     ) {
         $this->storage = $storage;
         $this->session = $session;
@@ -107,6 +129,7 @@ class RememberService
         $this->cookie = $cookie;
         $this->name = $name;
         $this->ttl = $ttl;
+        $this->user_loader = $user_loader;
     }
 
     /**
@@ -156,6 +179,10 @@ class RememberService
      *
      * Only acts when the user is currently anonymous.
      *
+     * If a user loader was supplied, the restored user data is re-fetched from
+     * the source of truth; a null return from the loader revokes the token and
+     * leaves the user anonymous.
+     *
      * @param Auth $auth The authentication tracker.
      *
      * @param int $ttl Optional token lifetime override for the rotated token.
@@ -200,6 +227,21 @@ class RememberService
             return false;
         }
 
+        // Resolve the user data to restore. By default this is the snapshot
+        // captured when the token was issued; with a user loader it is re-read
+        // from the source of truth so admin-side changes take effect. A null
+        // return means the user is gone or disabled, so revoke the token rather
+        // than re-establish a session for them.
+        $userdata = $row['userdata'];
+        if ($this->user_loader !== null) {
+            $userdata = ($this->user_loader)($row['username']);
+            if ($userdata === null) {
+                $this->storage->deleteBySelector($parsed['selector']);
+                $this->cookie->delete($this->name);
+                return false;
+            }
+        }
+
         $started = $this->session->resume() || $this->session->start();
         if (! $started) {
             return false;
@@ -225,7 +267,7 @@ class RememberService
             time(),
             time(),
             $row['username'],
-            $row['userdata']
+            $userdata
         );
 
         return true;

--- a/src/Remember/RememberService.php
+++ b/src/Remember/RememberService.php
@@ -109,7 +109,7 @@ class RememberService
      *
      * @param int $ttl The token lifetime in seconds (default 30 days).
      *
-     * @param callable $user_loader An optional `fn(string $username): ?array`
+     * @param callable|null $user_loader An optional `fn(string $username): ?array`
      * to re-fetch fresh user data on resume; null (the default) replays the
      * stored snapshot instead.
      *

--- a/tests/Remember/RememberServiceTest.php
+++ b/tests/Remember/RememberServiceTest.php
@@ -22,7 +22,7 @@ class RememberServiceTest extends \PHPUnit\Framework\TestCase
         $this->phpfunc = new FakePhpfunc;
     }
 
-    protected function newService(array $cookie = array())
+    protected function newService(array $cookie = array(), ?callable $user_loader = null)
     {
         return new RememberService(
             $this->storage,
@@ -30,7 +30,8 @@ class RememberServiceTest extends \PHPUnit\Framework\TestCase
             new Token($this->phpfunc),
             new Cookie($this->phpfunc, $cookie),
             'remember',
-            2592000
+            2592000,
+            $user_loader
         );
     }
 
@@ -170,6 +171,57 @@ class RememberServiceTest extends \PHPUnit\Framework\TestCase
         $resume = $this->newService(array('remember' => $cookie_value));
         $this->assertFalse($resume->resume($auth));
         $this->assertCount(0, $this->storage->rows);
+    }
+
+    public function testResumeWithUserLoaderRefreshesUserData()
+    {
+        // issue a token carrying the snapshot userdata ('foo' => 'bar')
+        $service = $this->newService();
+        $service->remember($this->newAuth(Status::VALID));
+        $cookie_value = $this->phpfunc->cookies['remember']['value'];
+
+        // a loader that re-fetches fresh data from the "source of truth"
+        $seen_username = null;
+        $loader = function ($username) use (&$seen_username) {
+            $seen_username = $username;
+            return array('role' => 'admin');
+        };
+
+        $auth = $this->newAuth(Status::ANON);
+        $resume = $this->newService(array('remember' => $cookie_value), $loader);
+        $this->assertTrue($resume->resume($auth));
+
+        // the loader was called with the remembered username
+        $this->assertSame('boshag', $seen_username);
+
+        // the refreshed data replaces the stored snapshot; identity is kept
+        $this->assertTrue($auth->isRemembered());
+        $this->assertSame('boshag', $auth->getUserName());
+        $this->assertSame(array('role' => 'admin'), $auth->getUserData());
+    }
+
+    public function testResumeWithUserLoaderReturningNullRevokesToken()
+    {
+        // issue a token
+        $service = $this->newService();
+        $service->remember($this->newAuth(Status::VALID));
+        $cookie_value = $this->phpfunc->cookies['remember']['value'];
+        $this->assertCount(1, $this->storage->rows);
+
+        // the user no longer exists / is disabled in the source of truth
+        $loader = function ($username) {
+            return null;
+        };
+
+        $auth = $this->newAuth(Status::ANON);
+        $resume = $this->newService(array('remember' => $cookie_value), $loader);
+        $this->assertFalse($resume->resume($auth));
+
+        // no session established, and the token is revoked and cookie cleared
+        $this->assertTrue($auth->isAnon());
+        $this->assertCount(0, $this->storage->rows);
+        $this->assertSame('', $this->phpfunc->cookies['remember']['value']);
+        $this->assertSame(1, $this->phpfunc->cookies['remember']['options']['expires']);
     }
 
     public function testForgetDeletesTokenAndCookie()


### PR DESCRIPTION
RememberService::resume() can now re-fetch fresh user data from your source of truth instead of replaying the snapshot stored when the token was issued — so admin-side changes (roles, email, disabled accounts) take effect without waiting for a full login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remembered sessions can now optionally refresh user data on every `resume()`.
  * If a user-data loader is provided, it re-fetches details for the remembered username.
  * If the loader returns no user data, the remember token is revoked and its cookie is cleared.
* **Documentation**
  * Updated “Remember Me” docs with new guidance and a “Refreshing User Data On Resume” section, including the optional loader wiring example.
* **Tests**
  * Added coverage for resume with refreshed user data and for token revocation when the loader returns `null`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->