### PR TITLE
Api tokens

### DIFF
--- a/docs/_bookdown.json
+++ b/docs/_bookdown.json
@@ -6,6 +6,7 @@
         "oauth.md",
         "service-idioms.md",
         "remember-me.md",
+        "api-tokens.md",
         "throttling.md",
         "sessions.md",
         "di-configuration.md",

--- a/docs/api-tokens.md
+++ b/docs/api-tokens.md
@@ -1,0 +1,279 @@
+# API Tokens
+
+Cookies and `$_SESSION` are a poor fit for a REST API: sessions are stateful and
+lock, and a cookie sent automatically by the browser is what makes CSRF possible
+in the first place. API token authentication instead has the client send a
+credential in a header on every request. Nothing is stored between requests, so
+there is no session to lock and no cookie for a cross-site request to abuse.
+
+The token is **opaque**: a random string that means nothing by itself and is
+looked up server-side. Because the server owns the record, revoking a token is
+simply deleting a row, and it stops working immediately.
+
+> N.b.: JWTs are deliberately not shipped. Their one real advantage — verifying
+> without touching the store — is exactly what breaks revocation, and
+> deployments that need revocation end up adding a denylist, which restores the
+> per-request lookup while keeping JWT's much larger validation surface (`alg:
+> none`, HS/RS confusion, weak secrets, `exp`/`aud`/`iss` handling). If you need
+> JWT or [PASETO](https://paseto.io/) for a federated or cross-service topology,
+> verify it in your own code and use `forceLogin()`.
+
+## How A Token Is Built
+
+A token value is two parts joined by a colon:
+
+```
+3f2a9c81d4e6b70a:9c81d4e6b70a3f2a9c81d4e6b70a3f2a9c81d4e6b70a3f2a9c81d4e6b70a3f2a
+└─── selector ──┘ └──────────────────── validator ────────────────────────────┘
+```
+
+The **selector** is a public lookup key. The **validator** is the secret; only
+its SHA-256 hash is stored, and it is compared in constant time. So a leaked
+database yields no usable tokens, and an attacker who knows a selector still has
+nothing to present.
+
+This is the same split-token scheme used by [remember me](remember-me.md), with
+one deliberate difference: **API tokens are not rotated on use.** A remember-me
+cookie rotates its validator every time so a stolen cookie works only once, but
+an API token is routinely presented by several requests at once, and rotating it
+would invalidate the copies still in flight. Tokens end by revocation or expiry
+instead.
+
+## Token Storage
+
+Tokens live in a pluggable, server-side store implementing
+`Aura\Auth\Token\TokenStorageInterface`. A PDO implementation ships with the
+library; supply your own for anything else.
+
+Create a table (adjust the column types to your database):
+
+```sql
+CREATE TABLE aura_auth_token (
+    selector         VARCHAR(32)  NOT NULL PRIMARY KEY,
+    hashed_validator VARCHAR(64)  NOT NULL,
+    username         VARCHAR(255) NOT NULL,
+    userdata         TEXT         NULL,
+    label            VARCHAR(255) NULL,
+    expires          INTEGER      NOT NULL,
+    created_at       INTEGER      NOT NULL,
+    last_used_at     INTEGER      NULL
+);
+CREATE INDEX aura_auth_token_username ON aura_auth_token (username);
+```
+
+Then build the storage and service:
+
+```php
+$auth_factory = new \Aura\Auth\AuthFactory($_COOKIE);
+
+$storage = $auth_factory->newPdoTokenStorage($pdo);
+$token_service = $auth_factory->newTokenService($storage);
+```
+
+`newTokenService()` takes an options array with a `ttl` key — the default token
+lifetime in seconds, 30 days if unset.
+
+## Issuing A Token
+
+Issuing is an ordinary authenticated action: the user logs in however your
+application normally logs people in, and *then* asks for a token.
+
+```php
+$token = $token_service->issue(
+    $auth->getUserName(),   // who the token authenticates as
+    array(),                // arbitrary data to carry with it
+    'CI deploy'             // an optional human-readable label
+);
+
+echo $token; // 3f2a9c81d4e6b70a:9c81d4e6...
+```
+
+> N.b.: **Show the token to the user now.** Storage keeps only the hash of the
+> validator, so this return value is the one and only chance to see it. This is
+> intentional — it is the same property that makes a database leak harmless.
+
+Pass a fourth argument to override the lifetime for one token:
+
+```php
+$token = $token_service->issue($username, array(), 'short lived', 3600);
+```
+
+## Authenticating A Request
+
+Three objects: an `Auth` backed by an in-memory segment, a `HeaderAdapter` that
+reads the token, and an `ApiResumeService` that ties them together.
+
+```php
+$auth = $auth_factory->newApiInstance();
+
+$adapter = $auth_factory->newHeaderAdapter($token_service, $_SERVER);
+$api_resume = $auth_factory->newApiResumeService($adapter);
+
+try {
+    if ($api_resume->resume($auth)) {
+        // $auth->getUserName(), $auth->getUserData() are populated
+    } else {
+        http_response_code(401); // no usable credential
+    }
+} catch (\Aura\Auth\Exception\TokenExpired $e) {
+    http_response_code(401);
+    echo "Token expired at " . gmdate('c', $e->getExpires()) . "; issue a new one.";
+}
+```
+
+Use `newApiInstance()`, **not** `newInstance()`. The latter returns an `Auth`
+backed by a session segment, which silently discards its writes when no session
+is active — leaving you with an anonymous `Auth` even though the token verified.
+`newApiInstance()` uses an `ArraySegment` that holds the values for the duration
+of the request and then forgets them, which is the whole point.
+
+By default the adapter reads `Authorization: Bearer <token>`. The scheme is
+matched case-insensitively. To use a different header:
+
+```php
+$adapter = $auth_factory->newHeaderAdapter($token_service, $_SERVER, array(
+    'header' => 'HTTP_X_API_TOKEN',
+    'prefix' => '',   // read the header value verbatim
+));
+```
+
+> N.b.: Some server configurations drop the `Authorization` header before PHP
+> sees it. On Apache with CGI/FastCGI you may need
+> `CGIPassAuth On`, or an equivalent rewrite, for `$_SERVER['HTTP_AUTHORIZATION']`
+> to be populated.
+
+## What Verification Reports
+
+`resume()` returns `false` for a request with no usable credential, and throws
+only for expiry:
+
+| Situation | Result |
+|---|---|
+| No token in the request | `false` |
+| Malformed token value | `false` |
+| Unknown selector | `false` |
+| Validator does not match | `false` |
+| Genuine token, past expiry | throws `Exception\TokenExpired` |
+
+The middle three are deliberately indistinguishable. Telling an unknown selector
+apart from a wrong validator would reveal whether a given selector exists, and
+selectors travel in the clear as half of every token.
+
+Expiry is different: the validator is matched *before* the expiry is examined, so
+only a caller already holding the genuine token can trigger it. Reporting it
+therefore leaks nothing, and lets you answer "your token expired" rather than a
+flat refusal. The exception carries `getExpires()`.
+
+A failed verification does **not** delete the stored token. Deleting on a
+mismatch would let anyone who has merely seen a selector revoke somebody else's
+token by presenting it with a wrong validator.
+
+## Revoking Tokens
+
+```php
+// revoke the token in the current request (verified first)
+$token_service->revoke($token_value);
+
+// revoke from a management UI, where the user is already authenticated
+$token_service->revokeBySelector($selector);
+
+// "sign out everywhere"
+$token_service->revokeAll($username);
+```
+
+`revoke()` verifies the token before deleting, so holding a selector alone is not
+enough to revoke someone else's token. An expired token can still be revoked —
+its validator matched, so expiry should not be the reason it cannot be cleaned
+up. `revokeBySelector()` skips that check and so must never be handed a selector
+straight from an incoming request.
+
+`HeaderAdapter::logout()` revokes the request's token. There is no session to
+destroy, so logging out of a token-authenticated request means the token stops
+working everywhere it was copied to.
+
+Expired rows are not removed automatically. Sweep them periodically:
+
+```php
+$token_service->deleteExpired();
+```
+
+## Tracking Last Use
+
+Off by default. Turn it on with the third argument to the storage:
+
+```php
+$storage = $auth_factory->newPdoTokenStorage($pdo, 'aura_auth_token', true);
+```
+
+It buys "last used 3 days ago" reporting and lets you prune abandoned tokens. It
+costs an `UPDATE` on every authenticated request, against the same row that
+request already reads — noticeable on a busy API. The column exists either way,
+so enabling it later needs no migration.
+
+> N.b.: Concurrent requests bearing the same token race on that update, so the
+> value is a rough indication rather than an audit record. If you need a real
+> access trail, write a log.
+
+## Carrying Data With A Token: Scopes
+
+The `userdata` array is stored and handed back untouched — the library never
+interprets it. That is where per-token restrictions belong:
+
+```php
+$token = $token_service->issue($username, array(
+    'scopes' => array('read:builds', 'write:deploys'),
+), 'CI deploy');
+
+// later, on an authenticated request
+$scopes = $auth->getUserData()['scopes'] ?? null;
+```
+
+Enforcing scopes is **authorization**, which this library does not do. Aura.Auth
+answers *who are you*; deciding *what may you do* is your application's job, or
+that of a permissions library.
+
+When you do enforce them, the rule that matters is:
+
+```
+effective permission = the user's permissions ∩ the token's scopes
+```
+
+A token can only ever **narrow** what its owner may already do. It never grants
+anything. So a check looks like this:
+
+```php
+function can($auth, $action) {
+    // the user side: roles, ACL rules, whatever you model
+    if (! userCan($auth->getUserName(), $action)) {
+        return false;
+    }
+
+    // the token side: absent scopes (a session login) impose no ceiling
+    $scopes = $auth->getUserData()['scopes'] ?? null;
+    return $scopes === null || in_array($action, $scopes, true);
+}
+```
+
+> N.b.: Checking scopes *instead of* the user's permissions, rather than in
+> addition to them, is a privilege-escalation bug: a token claiming
+> `scopes => ['admin:*']` would grant admin rights to a user who has none. The
+> intersection is what keeps a leaked token bounded from both sides.
+
+## Why Not `session_set_save_handler`?
+
+A recurring suggestion is to keep sessions but store them in a database. That
+solves a different problem — it changes *where session data lives*, not how the
+client is identified, so you are still transporting a session ID in a cookie.
+
+Bending it into header auth means `session_id($token_from_header)`, which is
+worth avoiding: the token becomes the session ID and is therefore stored raw
+rather than hashed, PHP's session GC governs its lifetime instead of your policy,
+there is no row of your own to hold a label or scopes, and session locking — one
+of the reasons to leave sessions behind — comes back.
+
+## Sessions And Tokens Side By Side
+
+Nothing stops an application serving both. Build two `Auth` trackers from the
+same factory — `newInstance()` for browser traffic, `newApiInstance()` for API
+traffic — and pick per route. Both produce `Status::VALID` on success, so
+downstream authorization code does not care which door the user came through.

--- a/docs/di-configuration.md
+++ b/docs/di-configuration.md
@@ -2,35 +2,38 @@
 
 Here are some hints regarding configuration of Aura.Auth via Aura.Di.
 
+> N.b.: This package no longer ships a `Common` config class, so nothing is
+> pre-wired for you. Every constructor parameter has to be supplied, including
+> the collaborators earlier versions filled in by default — the `verifier` on
+> the password-checking adapters, and the `phpfunc` proxy on the adapters that
+> call PHP's extension functions. The examples below spell all of them out.
+
 ## Aura\Auth\Adapter\HtpasswdAdapter
 
 ```php
-<?php
 $di->params['Aura\Auth\Adapter\HtpasswdAdapter'] = array(
     'file' => '/path/to/htpasswdfile',
+    'verifier' => $di->lazyNew('Aura\Auth\Verifier\HtpasswdVerifier'),
 );
-?>
 ```
 
 ## Aura\Auth\Adapter\ImapAdapter
 
 ```php
-<?php
 $di->params['Aura\Auth\Adapter\ImapAdapter'] = array(
+    'phpfunc' => $di->lazyNew('Aura\Auth\Phpfunc'),
     'mailbox' => '{mail.example.com:143/imap/secure}',
 );
-?>
 ```
 
 ## Aura\Auth\Adapter\LdapAdapter
 
 ```php
-<?php
 $di->params['Aura\Auth\Adapter\LdapAdapter'] = array(
+    'phpfunc' => $di->lazyNew('Aura\Auth\Phpfunc'),
     'server' => 'ldaps://ldap.example.com:636',
     'dnformat' => 'ou=Company Name,dc=Department Name,cn=users,uid=%s',
 );
-?>
 ```
 
 To use the "bind, search, rebind" pattern (see [Adapters](adapters.md)), add the
@@ -38,8 +41,8 @@ optional `options` and `search` params. When `search` is given, `dnformat` is
 ignored:
 
 ```php
-<?php
 $di->params['Aura\Auth\Adapter\LdapAdapter'] = array(
+    'phpfunc' => $di->lazyNew('Aura\Auth\Phpfunc'),
     'server' => 'ldaps://ldap.example.com:636',
     'dnformat' => 'uid=%s,dc=example,dc=org', // ignored when 'search' is set
     'options' => array(
@@ -54,15 +57,17 @@ $di->params['Aura\Auth\Adapter\LdapAdapter'] = array(
         'attributes' => array('cn', 'mail'),
     ),
 );
-?>
 ```
 
 ## Aura\Auth\Adapter\PdoAdapter
 
 ```php
-<?php
 $di->params['Aura\Auth\Adapter\PdoAdapter'] = array(
     'pdo' => $di->lazyGet('your_pdo_connection_service'),
+    'verifier' => $di->lazyNew(
+        'Aura\Auth\Verifier\PasswordVerifier',
+        array('algo' => PASSWORD_BCRYPT)
+    ),
     'cols' => array(
         'username_column',
         'password_column',
@@ -70,5 +75,92 @@ $di->params['Aura\Auth\Adapter\PdoAdapter'] = array(
     'from' => 'users_table',
     'where' => '',
 );
-?>
 ```
+
+## Aura\Auth\Remember\RememberService
+
+See [Remember Me](remember-me.md) for what these pieces do.
+
+```php
+$di->params['Aura\Auth\Remember\PdoRememberStorage'] = array(
+    'pdo' => $di->lazyGet('your_pdo_connection_service'),
+    'table' => 'aura_auth_remember',
+);
+
+$di->params['Aura\Auth\Remember\Cookie'] = array(
+    'phpfunc' => $di->lazyNew('Aura\Auth\Phpfunc'),
+    'cookie' => $_COOKIE,
+);
+
+$di->params['Aura\Auth\Remember\RememberService'] = array(
+    'storage' => $di->lazyNew('Aura\Auth\Remember\PdoRememberStorage'),
+    'session' => $di->lazyGet('your_session_service'),
+    'token' => $di->lazyNew('Aura\Auth\Token\SplitToken', array(
+        'phpfunc' => $di->lazyNew('Aura\Auth\Phpfunc'),
+    )),
+    'cookie' => $di->lazyNew('Aura\Auth\Remember\Cookie'),
+    'ttl' => 2592000,
+);
+```
+
+## Aura\Auth\Adapter\ThrottleAdapter
+
+See [Login Throttling](throttling.md). The adapter wraps another adapter, so
+`adapter` is whichever one actually checks credentials:
+
+```php
+$di->params['Aura\Auth\Throttle\PdoThrottleStorage'] = array(
+    'pdo' => $di->lazyGet('your_pdo_connection_service'),
+    'table' => 'aura_auth_throttle',
+    'window' => 900,
+);
+
+$di->params['Aura\Auth\Throttle\ThrottleService'] = array(
+    'storage' => $di->lazyNew('Aura\Auth\Throttle\PdoThrottleStorage'),
+    'options' => array('max_attempts' => 5, 'cap' => 900),
+);
+
+$di->params['Aura\Auth\Adapter\ThrottleAdapter'] = array(
+    'adapter' => $di->lazyNew('Aura\Auth\Adapter\PdoAdapter'),
+    'throttle' => $di->lazyNew('Aura\Auth\Throttle\ThrottleService'),
+);
+```
+
+## Aura\Auth\Adapter\HeaderAdapter
+
+See [API Tokens](api-tokens.md).
+
+```php
+$di->params['Aura\Auth\Token\PdoTokenStorage'] = array(
+    'pdo' => $di->lazyGet('your_pdo_connection_service'),
+    'table' => 'aura_auth_token',
+    'track_last_used' => false,
+);
+
+$di->params['Aura\Auth\Token\TokenService'] = array(
+    'storage' => $di->lazyNew('Aura\Auth\Token\PdoTokenStorage'),
+    'token' => $di->lazyNew('Aura\Auth\Token\SplitToken', array(
+        'phpfunc' => $di->lazyNew('Aura\Auth\Phpfunc'),
+    )),
+    'ttl' => 2592000,
+);
+
+$di->params['Aura\Auth\Adapter\HeaderAdapter'] = array(
+    'token_service' => $di->lazyNew('Aura\Auth\Token\TokenService'),
+    'server' => $_SERVER,
+    'options' => array('header' => 'HTTP_AUTHORIZATION', 'prefix' => 'Bearer '),
+);
+
+$di->params['Aura\Auth\Service\ApiResumeService'] = array(
+    'adapter' => $di->lazyNew('Aura\Auth\Adapter\HeaderAdapter'),
+);
+```
+
+> N.b.: An `Auth` used for stateless requests must be built with an
+> `ArraySegment`, not the session segment, or its writes are discarded:
+>
+> ```php
+> $api_auth = $di->lazyNew('Aura\Auth\Auth', array(
+>     'segment' => $di->lazyNew('Aura\Auth\Session\ArraySegment'),
+> ));
+> ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,8 @@
 - [OAuth 2.0](oauth.md)
 - [Service Idioms](service-idioms.md)
 - [Remember Me](remember-me.md)
+- [API Tokens](api-tokens.md)
+- [Login Throttling](throttling.md)
 - [Session Management](sessions.md)
 - [DI Configuration](di-configuration.md)
 - [Upgrade Guide: 4.x → 6.0.0](upgrade.md)

--- a/src/Adapter/HeaderAdapter.php
+++ b/src/Adapter/HeaderAdapter.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Auth\Adapter;
+
+use Aura\Auth\Auth;
+use Aura\Auth\Exception\TokenExpired;
+use Aura\Auth\Exception\TokenInvalid;
+use Aura\Auth\Exception\TokenMissing;
+use Aura\Auth\Status;
+use Aura\Auth\Token\TokenService;
+
+/**
+ *
+ * Authenticates a request from an opaque API token carried in an HTTP header.
+ *
+ * This is the stateless counterpart to the session-backed adapters: nothing is
+ * written to $_SESSION and no cookie is set or read. Each request stands alone,
+ * carrying its own credential, which is what makes it a fit for REST APIs —
+ * there is no session to lock, and no cookie for a cross-site request to abuse.
+ *
+ * Pair it with {@see \Aura\Auth\Service\ApiResumeService} and an
+ * {@see \Aura\Auth\Session\ArraySegment}-backed {@see Auth}.
+ *
+ * Tokens are issued by {@see TokenService::issue()}, not by this adapter:
+ * exchanging a password for a token is an ordinary login, so it belongs to
+ * whichever adapter already verifies the user's credentials.
+ *
+ * @package Aura.Auth
+ *
+ */
+class HeaderAdapter extends AbstractAdapter
+{
+    /**
+     *
+     * The token issuing and verification service.
+     *
+     * @var TokenService
+     *
+     */
+    protected $token_service;
+
+    /**
+     *
+     * A copy of $_SERVER (or an equivalent map of request headers).
+     *
+     * @var array
+     *
+     */
+    protected $server;
+
+    /**
+     *
+     * The $_SERVER key to read the token from.
+     *
+     * @var string
+     *
+     */
+    protected $header;
+
+    /**
+     *
+     * A scheme prefix to strip from the header value, e.g. "Bearer ".
+     *
+     * @var string
+     *
+     */
+    protected $prefix;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param TokenService $token_service The token verification service.
+     *
+     * @param array $server A copy of $_SERVER.
+     *
+     * @param array $options Optional keys: `header`, the $_SERVER key holding
+     * the token (default `HTTP_AUTHORIZATION`); and `prefix`, a scheme prefix
+     * to strip from it (default `Bearer `). Pass an empty prefix to read the
+     * header value verbatim, e.g. for a bare `X-Api-Token` header.
+     *
+     */
+    public function __construct(
+        TokenService $token_service,
+        array $server,
+        array $options = array()
+    ) {
+        $this->token_service = $token_service;
+        $this->server = $server;
+        $this->header = isset($options['header'])
+            ? $options['header']
+            : 'HTTP_AUTHORIZATION';
+        $this->prefix = isset($options['prefix'])
+            ? $options['prefix']
+            : 'Bearer ';
+    }
+
+    /**
+     *
+     * Verifies the presented token and returns its login data.
+     *
+     * @param array $input Optional credential input; a `token` key overrides
+     * the request header, which is useful when the token arrives by some other
+     * route (a query parameter on a websocket handshake, say).
+     *
+     * @return array A `list($username, $userdata)` pair.
+     *
+     * @throws TokenMissing when no token was presented.
+     *
+     * @throws TokenInvalid when the token is malformed, unknown, or does not
+     * match. These are deliberately not distinguished.
+     *
+     * @throws TokenExpired when the token is genuine but past its expiry.
+     *
+     */
+    public function login(array $input): array
+    {
+        $value = isset($input['token']) ? $input['token'] : $this->getToken();
+
+        if ($value === null || $value === '') {
+            throw new TokenMissing;
+        }
+
+        // TokenExpired propagates: the caller has proven it holds the real
+        // token, so it can be told to get a fresh one.
+        $row = $this->token_service->verify($value);
+
+        if (! $row) {
+            throw new TokenInvalid;
+        }
+
+        return array($row['username'], $row['userdata']);
+    }
+
+    /**
+     *
+     * Authenticates the request from its token, if it carries a usable one.
+     *
+     * A missing or invalid token leaves the Auth object untouched — anonymous —
+     * rather than throwing, so that this adapter can sit in a chain that also
+     * serves unauthenticated requests. An expired token still throws, since
+     * silently treating a request as anonymous when the client believes it is
+     * authenticated is the more confusing outcome, and the client has proven it
+     * holds the real token.
+     *
+     * @param Auth $auth The authentication object to populate.
+     *
+     * @return void
+     *
+     * @throws TokenExpired when the token is genuine but past its expiry.
+     *
+     */
+    public function resume(Auth $auth): void
+    {
+        try {
+            list($username, $userdata) = $this->login(array());
+        } catch (TokenMissing $e) {
+            return;
+        } catch (TokenInvalid $e) {
+            return;
+        }
+
+        $now = time();
+        $auth->set(Status::VALID, $now, $now, $username, $userdata);
+    }
+
+    /**
+     *
+     * Revokes the token the request was authenticated with.
+     *
+     * There is no session to destroy, so "logging out" of a token-authenticated
+     * request means revoking that token server-side; every other copy of it
+     * stops working too.
+     *
+     * @param Auth $auth The authentication object being logged out.
+     *
+     * @param string $status The new authentication status.
+     *
+     * @return void
+     *
+     */
+    public function logout(Auth $auth, $status = Status::ANON): void
+    {
+        $value = $this->getToken();
+        if ($value !== null && $value !== '') {
+            $this->token_service->revoke($value);
+        }
+    }
+
+    /**
+     *
+     * Reads the token out of the request headers.
+     *
+     * @return string|null The token value, or null if absent or if the header
+     * does not carry the expected scheme prefix.
+     *
+     */
+    protected function getToken(): ?string
+    {
+        if (! isset($this->server[$this->header])) {
+            return null;
+        }
+
+        $value = trim((string) $this->server[$this->header]);
+
+        if ($this->prefix === '') {
+            return ($value === '') ? null : $value;
+        }
+
+        // compare the scheme case-insensitively: RFC 7235 makes it a
+        // case-insensitive token, and clients differ on "Bearer" vs "bearer"
+        $len = strlen($this->prefix);
+        if (strncasecmp($value, $this->prefix, $len) !== 0) {
+            return null;
+        }
+
+        $value = trim(substr($value, $len));
+        return ($value === '') ? null : $value;
+    }
+}

--- a/src/AuthFactory.php
+++ b/src/AuthFactory.php
@@ -24,6 +24,9 @@ use Aura\Auth\Throttle;
 use Aura\Auth\Throttle\ThrottleStorageInterface;
 use Aura\Auth\Throttle\ThrottleService;
 use Aura\Auth\Throttle\RedisClientInterface;
+use Aura\Auth\Token;
+use Aura\Auth\Token\TokenService;
+use Aura\Auth\Token\TokenStorageInterface;
 use PDO;
 
 /**
@@ -327,6 +330,110 @@ class AuthFactory
             $client = new Throttle\NativeRedisClient($client);
         }
         return new Throttle\RedisThrottleStorage($client, $prefix, $window);
+    }
+
+    /**
+     *
+     * Returns a new authentication tracker for a stateless request.
+     *
+     * Unlike newInstance(), this is backed by an in-memory segment rather than
+     * a session one, so nothing is written to $_SESSION. Use it for requests
+     * authenticated from a header; use newInstance() for the session flows.
+     *
+     * @return Auth
+     *
+     */
+    public function newApiInstance(): Auth
+    {
+        return new Auth(new Session\ArraySegment);
+    }
+
+    /**
+     *
+     * Returns a new API token service.
+     *
+     * @param TokenStorageInterface $storage Server-side token storage.
+     *
+     * @param array $options Optional key: `ttl`, the default token lifetime in
+     * seconds (default 30 days).
+     *
+     * @return TokenService
+     *
+     */
+    public function newTokenService(
+        TokenStorageInterface $storage,
+        array $options = array()
+    ): TokenService {
+        $ttl = isset($options['ttl']) ? $options['ttl'] : 2592000;
+
+        return new Token\TokenService(
+            $storage,
+            new Token\SplitToken(new Phpfunc),
+            $ttl
+        );
+    }
+
+    /**
+     *
+     * Returns a new PDO-backed API token storage.
+     *
+     * @param PDO $pdo A PDO connection.
+     *
+     * @param string $table The table holding the tokens.
+     *
+     * @param bool $track_last_used Whether to record when each token was last
+     * presented. Off by default: it costs an UPDATE on every authenticated
+     * request. The column exists either way, so turning this on later needs no
+     * migration.
+     *
+     * @return Token\PdoTokenStorage
+     *
+     */
+    public function newPdoTokenStorage(
+        PDO $pdo,
+        $table = 'aura_auth_token',
+        $track_last_used = false
+    ): Token\PdoTokenStorage {
+        return new Token\PdoTokenStorage($pdo, $table, $track_last_used);
+    }
+
+    /**
+     *
+     * Returns a new header-token adapter.
+     *
+     * @param TokenService $token_service The token verification service.
+     *
+     * @param array $server A copy of $_SERVER.
+     *
+     * @param array $options Optional keys: `header`, the $_SERVER key holding
+     * the token (default `HTTP_AUTHORIZATION`); and `prefix`, a scheme prefix
+     * to strip from it (default `Bearer `).
+     *
+     * @return Adapter\HeaderAdapter
+     *
+     */
+    public function newHeaderAdapter(
+        TokenService $token_service,
+        array $server,
+        array $options = array()
+    ): Adapter\HeaderAdapter {
+        return new Adapter\HeaderAdapter($token_service, $server, $options);
+    }
+
+    /**
+     *
+     * Returns a new stateless resume service.
+     *
+     * @param AdapterInterface $adapter An adapter that authenticates from the
+     * request itself, such as an Adapter\HeaderAdapter.
+     *
+     * @return Service\ApiResumeService
+     *
+     */
+    public function newApiResumeService(
+        AdapterInterface $adapter
+    ): Service\ApiResumeService {
+        return new Service\ApiResumeService($adapter);
     }
 
     /**

--- a/src/AuthFactory.php
+++ b/src/AuthFactory.php
@@ -219,7 +219,7 @@ class AuthFactory
         return new Remember\RememberService(
             $storage,
             $this->session,
-            new Remember\Token($phpfunc),
+            new Token\SplitToken($phpfunc),
             new Remember\Cookie($phpfunc, $this->cookie, $options),
             $name,
             $ttl,

--- a/src/Exception/TokenExpired.php
+++ b/src/Exception/TokenExpired.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Auth\Exception;
+
+use Aura\Auth\Exception;
+
+/**
+ *
+ * Thrown when a presented API token is genuine but has passed its expiry.
+ *
+ * This is deliberately the ONLY verification failure that is distinguishable
+ * from the others: it is raised only after the validator has been matched, so
+ * reaching it proves the caller holds the real token and learns nothing new.
+ * Unknown selectors and mismatched validators both yield a plain null instead,
+ * so that they cannot be told apart and used to enumerate tokens.
+ *
+ * Carries the expiry time, so the application can tell the client how stale
+ * the token is and prompt for a new one.
+ *
+ * @package Aura.Auth
+ *
+ */
+class TokenExpired extends Exception
+{
+    /**
+     *
+     * The Unix time at which the token expired.
+     *
+     * @var int
+     *
+     */
+    protected $expires = 0;
+
+    /**
+     *
+     * Named constructor: build the exception from an expiry time.
+     *
+     * @param int $expires The Unix time at which the token expired.
+     *
+     * @return self
+     *
+     */
+    public static function at(int $expires): self
+    {
+        $e = new self(
+            "The API token expired at " . gmdate('Y-m-d H:i:s', $expires) . " UTC."
+        );
+        $e->expires = $expires;
+        return $e;
+    }
+
+    /**
+     *
+     * Returns the Unix time at which the token expired.
+     *
+     * @return int
+     *
+     */
+    public function getExpires(): int
+    {
+        return $this->expires;
+    }
+}

--- a/src/Exception/TokenInvalid.php
+++ b/src/Exception/TokenInvalid.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Auth\Exception;
+
+use Aura\Auth\Exception;
+
+/**
+ *
+ * Thrown when a presented API token is not usable.
+ *
+ * Raised alike for a malformed value, an unknown selector, and a validator
+ * that does not match, so that the three cannot be told apart. Distinguishing
+ * an unknown selector from a wrong validator would reveal whether a given
+ * selector exists, and selectors travel in the clear as half of the token.
+ *
+ * @package Aura.Auth
+ *
+ */
+class TokenInvalid extends Exception
+{
+}

--- a/src/Exception/TokenMissing.php
+++ b/src/Exception/TokenMissing.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Auth\Exception;
+
+use Aura\Auth\Exception;
+
+/**
+ *
+ * Thrown when no API token was presented at all.
+ *
+ * Distinct from {@see TokenInvalid}: this says the request carried no
+ * credential, not that it carried a bad one, which lets an application answer
+ * with a challenge rather than a rejection.
+ *
+ * @package Aura.Auth
+ *
+ */
+class TokenMissing extends Exception
+{
+}

--- a/src/Remember/RememberService.php
+++ b/src/Remember/RememberService.php
@@ -9,6 +9,7 @@
 namespace Aura\Auth\Remember;
 
 use Aura\Auth\Auth;
+use Aura\Auth\Token\SplitToken;
 use Aura\Auth\Status;
 use Aura\Session_Interface\SessionInterface;
 
@@ -50,7 +51,7 @@ class RememberService
      *
      * The split-token helper.
      *
-     * @var Token
+     * @var SplitToken
      *
      */
     protected $token;
@@ -101,7 +102,7 @@ class RememberService
      *
      * @param SessionInterface $session A session manager.
      *
-     * @param Token $token The split-token helper.
+     * @param SplitToken $token The split-token helper.
      *
      * @param Cookie $cookie The cookie reader/writer.
      *
@@ -117,7 +118,7 @@ class RememberService
     public function __construct(
         RememberStorageInterface $storage,
         SessionInterface $session,
-        Token $token,
+        SplitToken $token,
         Cookie $cookie,
         $name = 'remember',
         $ttl = 2592000,
@@ -165,7 +166,7 @@ class RememberService
 
         $this->cookie->set(
             $this->name,
-            $this->token->makeCookieValue($selector, $validator),
+            $this->token->makeValue($selector, $validator),
             $expires
         );
 
@@ -206,7 +207,7 @@ class RememberService
         }
 
         // A cookie was present but is malformed; clear it.
-        $parsed = $this->token->parseCookieValue($value);
+        $parsed = $this->token->parseValue($value);
         if (! $parsed) {
             $this->cookie->delete($this->name);
             return false;
@@ -258,7 +259,7 @@ class RememberService
         );
         $this->cookie->set(
             $this->name,
-            $this->token->makeCookieValue($parsed['selector'], $validator),
+            $this->token->makeValue($parsed['selector'], $validator),
             $expires
         );
 
@@ -286,7 +287,7 @@ class RememberService
      */
     public function forget(?Auth $auth = null): void
     {
-        $parsed = $this->token->parseCookieValue(
+        $parsed = $this->token->parseValue(
             $this->cookie->get($this->name)
         );
         if ($parsed) {

--- a/src/Service/ApiResumeService.php
+++ b/src/Service/ApiResumeService.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Auth\Service;
+
+use Aura\Auth\Adapter\AdapterInterface;
+use Aura\Auth\Auth;
+
+/**
+ *
+ * Establishes authentication for a stateless request.
+ *
+ * This is the counterpart to {@see ResumeService}, minus everything that
+ * assumes a session. ResumeService resumes the session first and gates the
+ * adapter behind an idle/expiry {@see \Aura\Auth\Session\Timer}; neither makes
+ * sense for a request that carries its own credential and ends. There is no
+ * session to resume, and the credential's own expiry governs its lifetime, so
+ * an idle timer would be measuring nothing.
+ *
+ * Give it an adapter that authenticates from the request itself — typically
+ * {@see \Aura\Auth\Adapter\HeaderAdapter} — and an {@see Auth} backed by an
+ * {@see \Aura\Auth\Session\ArraySegment}, so no session is touched at any point.
+ *
+ * @package Aura.Auth
+ *
+ */
+class ApiResumeService
+{
+    /**
+     *
+     * An adapter that authenticates from the request.
+     *
+     * @var AdapterInterface
+     *
+     */
+    protected $adapter;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param AdapterInterface $adapter An adapter that authenticates from the
+     * request, such as {@see \Aura\Auth\Adapter\HeaderAdapter}.
+     *
+     */
+    public function __construct(AdapterInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     *
+     * Authenticates the current request, if it carries a usable credential.
+     *
+     * @param Auth $auth The authentication tracker to populate.
+     *
+     * @return bool True if the request was authenticated; false if it carried
+     * no usable credential, leaving the tracker anonymous.
+     *
+     * @throws \Aura\Auth\Exception\TokenExpired when the request presents a
+     * genuine but expired token, so the application can answer with something
+     * more useful than a flat refusal.
+     *
+     */
+    public function resume(Auth $auth): bool
+    {
+        $this->adapter->resume($auth);
+        return ! $auth->isAnon();
+    }
+}

--- a/src/Session/ArraySegment.php
+++ b/src/Session/ArraySegment.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Auth\Session;
+
+/**
+ *
+ * A segment held entirely in memory, for authentication that must not touch
+ * $_SESSION — API requests authenticated from a header, for instance.
+ *
+ * {@see Segment} silently discards writes when no session is active, which is
+ * correct for its purpose but fatal here: {@see \Aura\Auth\Auth} keeps no state
+ * of its own and reads every value back out of its segment, so a discarded
+ * write means an authenticated user reads back as anonymous within the very
+ * same request. This implementation simply keeps the values, so the handoff
+ * works with no session involved.
+ *
+ * Nothing is persisted: the values live for one request and are gone. That is
+ * the intent — a stateless request re-authenticates from the credential it was
+ * given rather than restoring anything.
+ *
+ * @package Aura.Auth
+ *
+ */
+class ArraySegment implements SegmentInterface
+{
+    /**
+     *
+     * The segment values.
+     *
+     * @var array
+     *
+     */
+    protected $data = array();
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param array $data Initial segment values.
+     *
+     */
+    public function __construct(array $data = array())
+    {
+        $this->data = $data;
+    }
+
+    /**
+     *
+     * Gets a value from the segment.
+     *
+     * @param string $key A key for the segment value.
+     *
+     * @param mixed $alt Return this value if the segment key does not exist.
+     *
+     * @return mixed
+     *
+     */
+    public function get(string $key, mixed $alt = null): mixed
+    {
+        if (array_key_exists($key, $this->data)) {
+            return $this->data[$key];
+        }
+
+        return $alt;
+    }
+
+    /**
+     *
+     * Sets a value in the segment.
+     *
+     * @param string $key The key in the segment.
+     *
+     * @param mixed $val The value to set.
+     *
+     */
+    public function set(string $key, mixed $val): void
+    {
+        $this->data[$key] = $val;
+    }
+}

--- a/src/Token/PdoTokenStorage.php
+++ b/src/Token/PdoTokenStorage.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Auth\Token;
+
+use PDO;
+
+/**
+ *
+ * Stores API tokens in an SQL table via PDO.
+ *
+ * Expected table (adjust types to your database):
+ *
+ *     CREATE TABLE aura_auth_token (
+ *         selector         VARCHAR(32)  NOT NULL PRIMARY KEY,
+ *         hashed_validator VARCHAR(64)  NOT NULL,
+ *         username         VARCHAR(255) NOT NULL,
+ *         userdata         TEXT         NULL,
+ *         label            VARCHAR(255) NULL,
+ *         expires          INTEGER      NOT NULL,
+ *         created_at       INTEGER      NOT NULL,
+ *         last_used_at     INTEGER      NULL
+ *     );
+ *     CREATE INDEX aura_auth_token_username ON aura_auth_token (username);
+ *
+ * The `last_used_at` column is present whether or not last-use tracking is
+ * enabled, so that turning tracking on later requires no migration.
+ *
+ * @package Aura.Auth
+ *
+ */
+class PdoTokenStorage implements TokenStorageInterface
+{
+    /**
+     *
+     * A PDO connection.
+     *
+     * @var PDO
+     *
+     */
+    protected $pdo;
+
+    /**
+     *
+     * The table holding the tokens.
+     *
+     * @var string
+     *
+     */
+    protected $table;
+
+    /**
+     *
+     * Whether to record the time a token was last presented.
+     *
+     * @var bool
+     *
+     */
+    protected $track_last_used;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param PDO $pdo A PDO connection.
+     *
+     * @param string $table The table holding the tokens.
+     *
+     * @param bool $track_last_used Whether to record the time a token was last
+     * presented. Off by default: it costs an UPDATE on every authenticated
+     * request, against the same row that request already reads. Turning it on
+     * buys "last used" reporting and the ability to prune abandoned tokens.
+     * Note that concurrent requests bearing the same token race on the update,
+     * so the value is a rough indication rather than an audit record.
+     *
+     */
+    public function __construct(
+        PDO $pdo,
+        $table = 'aura_auth_token',
+        $track_last_used = false
+    ) {
+        $this->pdo = $pdo;
+        $this->table = $table;
+        $this->track_last_used = (bool) $track_last_used;
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     *
+     */
+    public function create(
+        $selector,
+        $hashed_validator,
+        $username,
+        array $userdata,
+        $expires,
+        $created_at,
+        $label = null
+    ): void {
+        $stm = "INSERT INTO {$this->table} "
+             . "(selector, hashed_validator, username, userdata, label, expires, created_at) "
+             . "VALUES (:selector, :hashed_validator, :username, :userdata, :label, :expires, :created_at)";
+        $sth = $this->pdo->prepare($stm);
+        $sth->execute(array(
+            'selector' => $selector,
+            'hashed_validator' => $hashed_validator,
+            'username' => $username,
+            'userdata' => json_encode($userdata),
+            'label' => $label,
+            'expires' => $expires,
+            'created_at' => $created_at,
+        ));
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     *
+     */
+    public function findBySelector($selector): ?array
+    {
+        $stm = "SELECT selector, hashed_validator, username, userdata, label, "
+             . "expires, created_at, last_used_at "
+             . "FROM {$this->table} WHERE selector = :selector";
+        $sth = $this->pdo->prepare($stm);
+        $sth->execute(array('selector' => $selector));
+        $row = $sth->fetch(PDO::FETCH_ASSOC);
+
+        if (! $row) {
+            return null;
+        }
+
+        $userdata = json_decode((string) $row['userdata'], true);
+        $row['userdata'] = is_array($userdata) ? $userdata : array();
+        $row['expires'] = (int) $row['expires'];
+        $row['created_at'] = (int) $row['created_at'];
+        $row['last_used_at'] = ($row['last_used_at'] === null)
+            ? null
+            : (int) $row['last_used_at'];
+        return $row;
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     *
+     * A no-op unless last-use tracking was enabled in the constructor.
+     *
+     */
+    public function touch($selector, $now): void
+    {
+        if (! $this->track_last_used) {
+            return;
+        }
+
+        $stm = "UPDATE {$this->table} SET last_used_at = :now "
+             . "WHERE selector = :selector";
+        $sth = $this->pdo->prepare($stm);
+        $sth->execute(array(
+            'now' => $now,
+            'selector' => $selector,
+        ));
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     *
+     */
+    public function deleteBySelector($selector): void
+    {
+        $stm = "DELETE FROM {$this->table} WHERE selector = :selector";
+        $sth = $this->pdo->prepare($stm);
+        $sth->execute(array('selector' => $selector));
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     *
+     */
+    public function deleteByUsername($username): void
+    {
+        $stm = "DELETE FROM {$this->table} WHERE username = :username";
+        $sth = $this->pdo->prepare($stm);
+        $sth->execute(array('username' => $username));
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     *
+     */
+    public function deleteExpired(): void
+    {
+        $stm = "DELETE FROM {$this->table} WHERE expires < :now";
+        $sth = $this->pdo->prepare($stm);
+        $sth->execute(array('now' => time()));
+    }
+}

--- a/src/Token/SplitToken.php
+++ b/src/Token/SplitToken.php
@@ -6,7 +6,7 @@
  * @license http://opensource.org/licenses/MIT-license.php MIT
  *
  */
-namespace Aura\Auth\Remember;
+namespace Aura\Auth\Token;
 
 use Aura\Auth\Phpfunc;
 
@@ -14,15 +14,18 @@ use Aura\Auth\Phpfunc;
  *
  * A split-token ("selector : validator") value object and helper.
  *
- * The cookie carries `selector:validator`. The `selector` is a public lookup
+ * A token value is `selector:validator`. The `selector` is a public lookup
  * key; the `validator` is a secret compared in constant time against a stored
  * SHA-256 hash. This is the scheme described at
  * https://paragonie.com/blog/2015/04/secure-authentication-php-with-long-term-persistence
  *
+ * The scheme is transport-agnostic: "remember me" carries the value in a
+ * cookie, while API authentication carries it in a request header.
+ *
  * @package Aura.Auth
  *
  */
-class Token
+class SplitToken
 {
     /**
      *
@@ -85,31 +88,31 @@ class Token
 
     /**
      *
-     * Builds the cookie value from a selector and validator.
+     * Builds the token value from a selector and validator.
      *
      * @param string $selector The public lookup key.
      *
      * @param string $validator The secret validator.
      *
-     * @return string The `selector:validator` cookie value.
+     * @return string The `selector:validator` token value.
      *
      */
-    public function makeCookieValue($selector, $validator): string
+    public function makeValue($selector, $validator): string
     {
         return $selector . ':' . $validator;
     }
 
     /**
      *
-     * Parses a `selector:validator` cookie value.
+     * Parses a `selector:validator` token value.
      *
-     * @param string $value The raw cookie value.
+     * @param string $value The raw token value.
      *
      * @return array|null An array with `selector` and `validator` keys, or null
      * if the value is malformed.
      *
      */
-    public function parseCookieValue($value): ?array
+    public function parseValue($value): ?array
     {
         if (! is_string($value) || strpos($value, ':') === false) {
             return null;
@@ -133,7 +136,7 @@ class Token
      *
      * @param string $hashed_validator The stored SHA-256 hash.
      *
-     * @param string $validator The validator presented in the cookie.
+     * @param string $validator The validator presented by the client.
      *
      * @return bool
      *

--- a/src/Token/TokenService.php
+++ b/src/Token/TokenService.php
@@ -8,6 +8,8 @@
  */
 namespace Aura\Auth\Token;
 
+use Aura\Auth\Exception\TokenExpired;
+
 /**
  *
  * Issues and verifies opaque API tokens using the split-token
@@ -122,9 +124,17 @@ class TokenService
      *
      * Verifies a plaintext token and returns its stored row.
      *
-     * Returns null for every kind of failure — malformed value, unknown
-     * selector, expired token, or a validator that does not match — so that a
-     * caller cannot distinguish them.
+     * Returns null for a malformed value, an unknown selector, or a validator
+     * that does not match. Unknown and mismatched in particular are made
+     * indistinguishable on purpose: telling them apart would reveal whether a
+     * given selector exists, and selectors travel in the clear as half of the
+     * token value.
+     *
+     * An expired token is the one failure reported distinctly, by throwing
+     * {@see \Aura\Auth\Exception\TokenExpired}. That is safe because the
+     * validator is matched first, so only a caller already holding the genuine
+     * token can reach it — and it lets an API answer "your token expired,
+     * please issue a new one" instead of a flat refusal.
      *
      * A failed verification deliberately does NOT delete the stored token. The
      * selector travels in the clear as half of the token value, so deleting on
@@ -137,6 +147,8 @@ class TokenService
      * @param string $value The plaintext `selector:validator` token value.
      *
      * @return array|null The stored token row, or null if verification failed.
+     *
+     * @throws TokenExpired when the token is genuine but past its expiry.
      *
      */
     public function verify($value): ?array
@@ -151,12 +163,16 @@ class TokenService
             return null;
         }
 
-        if ($row['expires'] < time()) {
+        // Match the validator BEFORE looking at the expiry. Reaching the
+        // expiry check therefore proves the caller holds the real token, which
+        // is what makes it safe to report expiry distinctly below. Checking
+        // expiry first would let an unknown-vs-existing selector be told apart.
+        if (! $this->token->verify($row['hashed_validator'], $parsed['validator'])) {
             return null;
         }
 
-        if (! $this->token->verify($row['hashed_validator'], $parsed['validator'])) {
-            return null;
+        if ($row['expires'] < time()) {
+            throw TokenExpired::at((int) $row['expires']);
         }
 
         // no-op unless the storage was built with last-use tracking on
@@ -170,7 +186,8 @@ class TokenService
      * Revokes a token, given its plaintext value.
      *
      * The token is verified before being deleted, so that holding a selector
-     * alone is not enough to revoke somebody else's token.
+     * alone is not enough to revoke somebody else's token. An already-expired
+     * token can still be revoked, since its validator matched.
      *
      * @param string $value The plaintext `selector:validator` token value.
      *
@@ -179,7 +196,16 @@ class TokenService
      */
     public function revoke($value): bool
     {
-        if (! $this->verify($value)) {
+        try {
+            $verified = (bool) $this->verify($value);
+        } catch (TokenExpired $e) {
+            // An expired token is still genuine — the validator matched — so
+            // let it be revoked rather than making expiry a reason it cannot
+            // be cleaned up.
+            $verified = true;
+        }
+
+        if (! $verified) {
             return false;
         }
 

--- a/src/Token/TokenService.php
+++ b/src/Token/TokenService.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Auth\Token;
+
+/**
+ *
+ * Issues and verifies opaque API tokens using the split-token
+ * (selector : validator) scheme with server-side storage.
+ *
+ * The plaintext token is returned exactly once, by issue(). Only the hash of
+ * its validator is stored, so a token that the application does not show to
+ * the user at issue time is not recoverable afterwards.
+ *
+ * Unlike "remember me" cookies, tokens are NOT rotated on use: an API token is
+ * routinely presented by several requests at once, and rotating it would
+ * invalidate the copies still in flight. Tokens end by explicit revocation or
+ * by expiry instead.
+ *
+ * @package Aura.Auth
+ *
+ */
+class TokenService
+{
+    /**
+     *
+     * Server-side token storage.
+     *
+     * @var TokenStorageInterface
+     *
+     */
+    protected $storage;
+
+    /**
+     *
+     * The split-token helper.
+     *
+     * @var SplitToken
+     *
+     */
+    protected $token;
+
+    /**
+     *
+     * The default token lifetime in seconds.
+     *
+     * @var int
+     *
+     */
+    protected $ttl;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param TokenStorageInterface $storage Server-side token storage.
+     *
+     * @param SplitToken $token The split-token helper.
+     *
+     * @param int $ttl The default token lifetime in seconds (default 30 days).
+     *
+     */
+    public function __construct(
+        TokenStorageInterface $storage,
+        SplitToken $token,
+        $ttl = 2592000
+    ) {
+        $this->storage = $storage;
+        $this->token = $token;
+        $this->ttl = $ttl;
+    }
+
+    /**
+     *
+     * Issues a new token and returns its plaintext value.
+     *
+     * The returned value is the ONLY chance to see the token: storage keeps
+     * just the hash of the validator. Show it to the user now or it is lost.
+     *
+     * @param string $username The user the token authenticates as.
+     *
+     * @param array $userdata Arbitrary application data to carry with the
+     * token. The library stores and returns this without interpreting it;
+     * applications that restrict a token's reach typically keep scopes here.
+     *
+     * @param string|null $label A human-readable name, e.g. "CI deploy".
+     *
+     * @param int|null $ttl Optional lifetime override, in seconds.
+     *
+     * @return string The plaintext `selector:validator` token value.
+     *
+     */
+    public function issue(
+        $username,
+        array $userdata = array(),
+        $label = null,
+        $ttl = null
+    ): string {
+        $now = time();
+        $selector = $this->token->newSelector();
+        $validator = $this->token->newValidator();
+
+        $this->storage->create(
+            $selector,
+            $this->token->hash($validator),
+            $username,
+            $userdata,
+            $now + (($ttl === null) ? $this->ttl : $ttl),
+            $now,
+            $label
+        );
+
+        return $this->token->makeValue($selector, $validator);
+    }
+
+    /**
+     *
+     * Verifies a plaintext token and returns its stored row.
+     *
+     * Returns null for every kind of failure — malformed value, unknown
+     * selector, expired token, or a validator that does not match — so that a
+     * caller cannot distinguish them.
+     *
+     * A failed verification deliberately does NOT delete the stored token. The
+     * selector travels in the clear as half of the token value, so deleting on
+     * a validator mismatch would let anyone who has merely seen a selector
+     * revoke somebody else's token by presenting it with a wrong validator.
+     * (This is the opposite of the "remember me" flow, where a mismatch is
+     * treated as evidence of a stolen cookie and the token is discarded.)
+     * Expired rows are cleared by deleteExpired() instead.
+     *
+     * @param string $value The plaintext `selector:validator` token value.
+     *
+     * @return array|null The stored token row, or null if verification failed.
+     *
+     */
+    public function verify($value): ?array
+    {
+        $parsed = $this->token->parseValue($value);
+        if (! $parsed) {
+            return null;
+        }
+
+        $row = $this->storage->findBySelector($parsed['selector']);
+        if (! $row) {
+            return null;
+        }
+
+        if ($row['expires'] < time()) {
+            return null;
+        }
+
+        if (! $this->token->verify($row['hashed_validator'], $parsed['validator'])) {
+            return null;
+        }
+
+        // no-op unless the storage was built with last-use tracking on
+        $this->storage->touch($parsed['selector'], time());
+
+        return $row;
+    }
+
+    /**
+     *
+     * Revokes a token, given its plaintext value.
+     *
+     * The token is verified before being deleted, so that holding a selector
+     * alone is not enough to revoke somebody else's token.
+     *
+     * @param string $value The plaintext `selector:validator` token value.
+     *
+     * @return bool True if a token was revoked.
+     *
+     */
+    public function revoke($value): bool
+    {
+        if (! $this->verify($value)) {
+            return false;
+        }
+
+        $parsed = $this->token->parseValue($value);
+        $this->storage->deleteBySelector($parsed['selector']);
+        return true;
+    }
+
+    /**
+     *
+     * Revokes a token by its selector, without seeing the validator.
+     *
+     * This is for application-side management — a "revoke" button next to a
+     * token in a list, where the user has already been authenticated by other
+     * means. Do NOT call it with a selector taken straight from an incoming
+     * request; use revoke() for that.
+     *
+     * @param string $selector The public lookup key.
+     *
+     * @return void
+     *
+     */
+    public function revokeBySelector($selector): void
+    {
+        $this->storage->deleteBySelector($selector);
+    }
+
+    /**
+     *
+     * Revokes every token belonging to a user ("revoke all my tokens").
+     *
+     * @param string $username The user name.
+     *
+     * @return void
+     *
+     */
+    public function revokeAll($username): void
+    {
+        $this->storage->deleteByUsername($username);
+    }
+
+    /**
+     *
+     * Deletes expired tokens (housekeeping); call this periodically.
+     *
+     * @return void
+     *
+     */
+    public function deleteExpired(): void
+    {
+        $this->storage->deleteExpired();
+    }
+}

--- a/src/Token/TokenService.php
+++ b/src/Token/TokenService.php
@@ -153,6 +153,43 @@ class TokenService
      */
     public function verify($value): ?array
     {
+        // The validator is matched BEFORE the expiry is looked at. Reaching
+        // the expiry check therefore proves the caller holds the real token,
+        // which is what makes it safe to report expiry distinctly. Checking
+        // expiry first would let an unknown-vs-existing selector be told apart.
+        $row = $this->findGenuine($value);
+        if (! $row) {
+            return null;
+        }
+
+        if ($row['expires'] < time()) {
+            throw TokenExpired::at((int) $row['expires']);
+        }
+
+        // no-op unless the storage was built with last-use tracking on
+        $this->storage->touch($row['selector'], time());
+
+        return $row;
+    }
+
+    /**
+     *
+     * Finds the stored row for a token whose validator matches.
+     *
+     * This is the single place the secret is compared, shared by verify() and
+     * revoke() so that the two cannot drift apart on it. It deliberately says
+     * nothing about expiry: callers decide what an expired-but-genuine token
+     * means to them.
+     *
+     * @param string $value The plaintext `selector:validator` token value.
+     *
+     * @return array|null The stored row, or null if the value is malformed,
+     * the selector is unknown, or the validator does not match. These are not
+     * distinguished, so that a caller cannot learn whether a selector exists.
+     *
+     */
+    protected function findGenuine($value): ?array
+    {
         $parsed = $this->token->parseValue($value);
         if (! $parsed) {
             return null;
@@ -163,20 +200,9 @@ class TokenService
             return null;
         }
 
-        // Match the validator BEFORE looking at the expiry. Reaching the
-        // expiry check therefore proves the caller holds the real token, which
-        // is what makes it safe to report expiry distinctly below. Checking
-        // expiry first would let an unknown-vs-existing selector be told apart.
         if (! $this->token->verify($row['hashed_validator'], $parsed['validator'])) {
             return null;
         }
-
-        if ($row['expires'] < time()) {
-            throw TokenExpired::at((int) $row['expires']);
-        }
-
-        // no-op unless the storage was built with last-use tracking on
-        $this->storage->touch($parsed['selector'], time());
 
         return $row;
     }
@@ -196,21 +222,15 @@ class TokenService
      */
     public function revoke($value): bool
     {
-        try {
-            $verified = (bool) $this->verify($value);
-        } catch (TokenExpired $e) {
-            // An expired token is still genuine — the validator matched — so
-            // let it be revoked rather than making expiry a reason it cannot
-            // be cleaned up.
-            $verified = true;
-        }
-
-        if (! $verified) {
+        // Expiry is not consulted: an expired token is still genuine, and
+        // expiry should not be the reason it cannot be cleaned up. Nor is the
+        // row touched — it is about to be deleted.
+        $row = $this->findGenuine($value);
+        if (! $row) {
             return false;
         }
 
-        $parsed = $this->token->parseValue($value);
-        $this->storage->deleteBySelector($parsed['selector']);
+        $this->storage->deleteBySelector($row['selector']);
         return true;
     }
 

--- a/src/Token/TokenStorageInterface.php
+++ b/src/Token/TokenStorageInterface.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Auth\Token;
+
+/**
+ *
+ * Server-side storage for API authentication tokens.
+ *
+ * Implementations persist a token as a `selector` (a public lookup key) and a
+ * `hashed_validator` (the SHA-256 hash of the secret validator). The raw
+ * validator is never stored; only its hash is kept, so that a leak of the
+ * storage backend does not by itself yield usable tokens.
+ *
+ * Note that this deliberately has no rotation method, unlike
+ * {@see \Aura\Auth\Remember\RememberStorageInterface}. A remember-me cookie
+ * rotates its validator on every use so that a stolen cookie is single-use;
+ * doing the same to an API token would break concurrent requests, because the
+ * first request to arrive would invalidate the token the others are still
+ * presenting. API tokens are instead revoked explicitly, or by expiry.
+ *
+ * A stored token row is an associative array with the keys:
+ *
+ * - `selector` (string) the public lookup key
+ * - `hashed_validator` (string) the SHA-256 hash of the secret validator
+ * - `username` (string) the user the token authenticates as
+ * - `userdata` (array) arbitrary application data carried with the token; the
+ *   library stores and returns it without interpreting it. Applications that
+ *   restrict what a token may do typically keep their scopes here. Note that
+ *   such scopes can only ever *narrow* what the user is already permitted to
+ *   do; they never grant anything on their own.
+ * - `label` (string|null) a human-readable name for the token, e.g. "CI deploy"
+ * - `expires` (int) the Unix time at which the token expires
+ * - `created_at` (int) the Unix time at which the token was issued
+ * - `last_used_at` (int|null) the Unix time the token was last presented, or
+ *   null if never used or if the implementation does not track it
+ *
+ * @package Aura.Auth
+ *
+ */
+interface TokenStorageInterface
+{
+    /**
+     *
+     * Persists a new token.
+     *
+     * @param string $selector The public lookup key.
+     *
+     * @param string $hashed_validator The SHA-256 hash of the secret validator.
+     *
+     * @param string $username The user the token authenticates as.
+     *
+     * @param array $userdata Arbitrary application data to carry with the token.
+     *
+     * @param int $expires The Unix time at which the token expires.
+     *
+     * @param int $created_at The Unix time at which the token was issued.
+     *
+     * @param string|null $label A human-readable name for the token.
+     *
+     * @return void
+     *
+     */
+    public function create(
+        $selector,
+        $hashed_validator,
+        $username,
+        array $userdata,
+        $expires,
+        $created_at,
+        $label = null
+    ): void;
+
+    /**
+     *
+     * Finds a token by its selector.
+     *
+     * @param string $selector The public lookup key.
+     *
+     * @return array|null The token row, or null if not found.
+     *
+     */
+    public function findBySelector($selector): ?array;
+
+    /**
+     *
+     * Records that a token was just used, if the implementation tracks it.
+     *
+     * Implementations that do not track last-use are expected to make this a
+     * no-op, so that callers may invoke it unconditionally.
+     *
+     * @param string $selector The public lookup key.
+     *
+     * @param int $now The Unix time at which the token was used.
+     *
+     * @return void
+     *
+     */
+    public function touch($selector, $now): void;
+
+    /**
+     *
+     * Deletes a token by its selector (revokes a single token).
+     *
+     * @param string $selector The public lookup key.
+     *
+     * @return void
+     *
+     */
+    public function deleteBySelector($selector): void;
+
+    /**
+     *
+     * Deletes all tokens for a user name (e.g. "revoke all my tokens").
+     *
+     * @param string $username The user name.
+     *
+     * @return void
+     *
+     */
+    public function deleteByUsername($username): void;
+
+    /**
+     *
+     * Deletes all expired tokens (housekeeping).
+     *
+     * @return void
+     *
+     */
+    public function deleteExpired(): void;
+}

--- a/tests/Adapter/HeaderAdapterTest.php
+++ b/tests/Adapter/HeaderAdapterTest.php
@@ -1,0 +1,216 @@
+<?php
+namespace Aura\Auth\Adapter;
+
+use Aura\Auth\Auth;
+use Aura\Auth\Exception\TokenExpired;
+use Aura\Auth\Exception\TokenInvalid;
+use Aura\Auth\Exception\TokenMissing;
+use Aura\Auth\Phpfunc;
+use Aura\Auth\Session\ArraySegment;
+use Aura\Auth\Status;
+use Aura\Auth\Token\FakeTokenStorage;
+use Aura\Auth\Token\SplitToken;
+use Aura\Auth\Token\TokenService;
+
+class HeaderAdapterTest extends \PHPUnit\Framework\TestCase
+{
+    protected $storage;
+
+    protected $service;
+
+    protected function setUp() : void
+    {
+        $this->storage = new FakeTokenStorage;
+        $this->service = new TokenService(
+            $this->storage,
+            new SplitToken(new Phpfunc)
+        );
+    }
+
+    protected function newAdapter(array $server, array $options = array())
+    {
+        return new HeaderAdapter($this->service, $server, $options);
+    }
+
+    protected function newAuth()
+    {
+        return new Auth(new ArraySegment);
+    }
+
+    public function testLoginFromBearerHeader()
+    {
+        $value = $this->service->issue('boshag', array('foo' => 'bar'));
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+        );
+
+        list($username, $userdata) = $adapter->login(array());
+        $this->assertSame('boshag', $username);
+        $this->assertSame(array('foo' => 'bar'), $userdata);
+    }
+
+    public function testSchemePrefixIsCaseInsensitive()
+    {
+        $value = $this->service->issue('boshag');
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'bearer ' . $value)
+        );
+
+        list($username) = $adapter->login(array());
+        $this->assertSame('boshag', $username);
+    }
+
+    public function testCustomHeaderAndEmptyPrefix()
+    {
+        $value = $this->service->issue('boshag');
+        $adapter = $this->newAdapter(
+            array('HTTP_X_API_TOKEN' => $value),
+            array('header' => 'HTTP_X_API_TOKEN', 'prefix' => '')
+        );
+
+        list($username) = $adapter->login(array());
+        $this->assertSame('boshag', $username);
+    }
+
+    public function testTokenInInputOverridesHeader()
+    {
+        $value = $this->service->issue('boshag');
+        $adapter = $this->newAdapter(array());
+
+        list($username) = $adapter->login(array('token' => $value));
+        $this->assertSame('boshag', $username);
+    }
+
+    public function testLoginThrowsWhenHeaderAbsent()
+    {
+        $this->expectException(TokenMissing::CLASS);
+        $this->newAdapter(array())->login(array());
+    }
+
+    public function testLoginThrowsWhenSchemeDoesNotMatch()
+    {
+        $value = $this->service->issue('boshag');
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'Basic ' . $value)
+        );
+
+        $this->expectException(TokenMissing::CLASS);
+        $adapter->login(array());
+    }
+
+    public function testLoginThrowsWhenSchemeHasNoValue()
+    {
+        $adapter = $this->newAdapter(array('HTTP_AUTHORIZATION' => 'Bearer '));
+
+        $this->expectException(TokenMissing::CLASS);
+        $adapter->login(array());
+    }
+
+    public function testLoginThrowsOnUnknownToken()
+    {
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'Bearer nosuch:validator')
+        );
+
+        $this->expectException(TokenInvalid::CLASS);
+        $adapter->login(array());
+    }
+
+    public function testLoginThrowsOnMalformedToken()
+    {
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'Bearer nocolon')
+        );
+
+        $this->expectException(TokenInvalid::CLASS);
+        $adapter->login(array());
+    }
+
+    public function testLoginThrowsOnExpiredToken()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+        $this->storage->rows[$parsed['selector']]['expires'] = time() - 1;
+
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+        );
+
+        $this->expectException(TokenExpired::CLASS);
+        $adapter->login(array());
+    }
+
+    public function testResumeAuthenticatesWithoutASession()
+    {
+        $this->assertFalse(isset($_SESSION));
+
+        $value = $this->service->issue('boshag', array('foo' => 'bar'));
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+        );
+
+        $auth = $this->newAuth();
+        $adapter->resume($auth);
+
+        $this->assertTrue($auth->isValid());
+        $this->assertSame(Status::VALID, $auth->getStatus());
+        $this->assertSame('boshag', $auth->getUserName());
+        $this->assertSame(array('foo' => 'bar'), $auth->getUserData());
+        $this->assertFalse(isset($_SESSION));
+    }
+
+    public function testResumeLeavesAuthAnonymousWhenNoToken()
+    {
+        $auth = $this->newAuth();
+        $this->newAdapter(array())->resume($auth);
+
+        $this->assertTrue($auth->isAnon());
+    }
+
+    public function testResumeLeavesAuthAnonymousWhenTokenInvalid()
+    {
+        $auth = $this->newAuth();
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'Bearer nosuch:validator')
+        );
+        $adapter->resume($auth);
+
+        $this->assertTrue($auth->isAnon());
+    }
+
+    public function testResumeThrowsOnExpiredToken()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+        $this->storage->rows[$parsed['selector']]['expires'] = time() - 1;
+
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+        );
+
+        $this->expectException(TokenExpired::CLASS);
+        $adapter->resume($this->newAuth());
+    }
+
+    public function testLogoutRevokesTheToken()
+    {
+        $value = $this->service->issue('boshag');
+        $adapter = $this->newAdapter(
+            array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+        );
+
+        $auth = $this->newAuth();
+        $adapter->resume($auth);
+        $adapter->logout($auth);
+
+        $this->assertNull($this->service->verify($value));
+    }
+
+    public function testLogoutWithoutATokenDoesNothing()
+    {
+        $adapter = $this->newAdapter(array());
+        $adapter->logout($this->newAuth());
+
+        $this->assertSame(array(), $this->storage->rows);
+    }
+}

--- a/tests/AuthFactoryTest.php
+++ b/tests/AuthFactoryTest.php
@@ -150,4 +150,84 @@ class AuthFactoryTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertInstanceOf('Aura\Auth\Adapter\ThrottleAdapter', $adapter);
     }
+
+    public function testNewApiInstanceUsesAnInMemorySegment()
+    {
+        $auth = $this->factory->newApiInstance();
+        $this->assertInstanceOf('Aura\Auth\Auth', $auth);
+
+        // it must round-trip with no session in play
+        $this->assertFalse(isset($_SESSION));
+        $auth->setUserName('boshag');
+        $this->assertSame('boshag', $auth->getUserName());
+    }
+
+    public function testNewTokenService()
+    {
+        $service = $this->factory->newTokenService(
+            new \Aura\Auth\Token\FakeTokenStorage()
+        );
+        $this->assertInstanceOf('Aura\Auth\Token\TokenService', $service);
+    }
+
+    public function testNewTokenServiceWithTtlOption()
+    {
+        $storage = new \Aura\Auth\Token\FakeTokenStorage();
+        $service = $this->factory->newTokenService($storage, array('ttl' => 60));
+
+        $before = time();
+        $service->issue('boshag');
+
+        $row = current($storage->rows);
+        $this->assertGreaterThanOrEqual($before + 60, $row['expires']);
+        $this->assertLessThanOrEqual(time() + 60, $row['expires']);
+    }
+
+    public function testNewPdoTokenStorage()
+    {
+        $storage = $this->factory->newPdoTokenStorage(new PDO('sqlite::memory:'));
+        $this->assertInstanceOf('Aura\Auth\Token\PdoTokenStorage', $storage);
+    }
+
+    public function testNewHeaderAdapter()
+    {
+        $service = $this->factory->newTokenService(
+            new \Aura\Auth\Token\FakeTokenStorage()
+        );
+        $adapter = $this->factory->newHeaderAdapter($service, array());
+        $this->assertInstanceOf('Aura\Auth\Adapter\HeaderAdapter', $adapter);
+    }
+
+    public function testNewApiResumeService()
+    {
+        $service = $this->factory->newTokenService(
+            new \Aura\Auth\Token\FakeTokenStorage()
+        );
+        $adapter = $this->factory->newHeaderAdapter($service, array());
+
+        $this->assertInstanceOf(
+            'Aura\Auth\Service\ApiResumeService',
+            $this->factory->newApiResumeService($adapter)
+        );
+    }
+
+    public function testFactoryWiresAnEndToEndStatelessRequest()
+    {
+        $storage = new \Aura\Auth\Token\FakeTokenStorage();
+        $service = $this->factory->newTokenService($storage);
+        $value = $service->issue('boshag', array('foo' => 'bar'));
+
+        $api = $this->factory->newApiResumeService(
+            $this->factory->newHeaderAdapter(
+                $service,
+                array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+            )
+        );
+
+        $auth = $this->factory->newApiInstance();
+        $this->assertTrue($api->resume($auth));
+        $this->assertSame('boshag', $auth->getUserName());
+        $this->assertSame(array('foo' => 'bar'), $auth->getUserData());
+        $this->assertFalse(isset($_SESSION));
+    }
 }

--- a/tests/Remember/RememberServiceTest.php
+++ b/tests/Remember/RememberServiceTest.php
@@ -4,6 +4,7 @@ namespace Aura\Auth\Remember;
 use Aura\Auth\Auth;
 use Aura\Auth\Status;
 use Aura\Auth\FakePhpfunc;
+use Aura\Auth\Token\SplitToken;
 use Aura\Auth\Session\FakeSession;
 use Aura\Auth\Session\FakeSegment;
 
@@ -27,7 +28,7 @@ class RememberServiceTest extends \PHPUnit\Framework\TestCase
         return new RememberService(
             $this->storage,
             $this->session,
-            new Token($this->phpfunc),
+            new SplitToken($this->phpfunc),
             new Cookie($this->phpfunc, $cookie),
             'remember',
             2592000,

--- a/tests/Service/ApiResumeServiceTest.php
+++ b/tests/Service/ApiResumeServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Aura\Auth\Service;
+
+use Aura\Auth\Adapter\HeaderAdapter;
+use Aura\Auth\Auth;
+use Aura\Auth\Exception\TokenExpired;
+use Aura\Auth\Phpfunc;
+use Aura\Auth\Session\ArraySegment;
+use Aura\Auth\Token\FakeTokenStorage;
+use Aura\Auth\Token\SplitToken;
+use Aura\Auth\Token\TokenService;
+
+class ApiResumeServiceTest extends \PHPUnit\Framework\TestCase
+{
+    protected $storage;
+
+    protected $service;
+
+    protected function setUp() : void
+    {
+        $this->storage = new FakeTokenStorage;
+        $this->service = new TokenService(
+            $this->storage,
+            new SplitToken(new Phpfunc)
+        );
+    }
+
+    protected function newApiResume(array $server)
+    {
+        return new ApiResumeService(
+            new HeaderAdapter($this->service, $server)
+        );
+    }
+
+    public function testResumeAuthenticatesFromHeader()
+    {
+        $value = $this->service->issue('boshag', array('foo' => 'bar'));
+        $api = $this->newApiResume(
+            array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+        );
+
+        $auth = new Auth(new ArraySegment);
+        $this->assertTrue($api->resume($auth));
+        $this->assertSame('boshag', $auth->getUserName());
+        $this->assertSame(array('foo' => 'bar'), $auth->getUserData());
+    }
+
+    public function testResumeTouchesNoSession()
+    {
+        $value = $this->service->issue('boshag');
+        $api = $this->newApiResume(
+            array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+        );
+
+        $this->assertFalse(isset($_SESSION));
+        $api->resume(new Auth(new ArraySegment));
+        $this->assertFalse(isset($_SESSION));
+    }
+
+    public function testResumeReturnsFalseWithoutAToken()
+    {
+        $auth = new Auth(new ArraySegment);
+
+        $this->assertFalse($this->newApiResume(array())->resume($auth));
+        $this->assertTrue($auth->isAnon());
+    }
+
+    public function testResumeReturnsFalseOnInvalidToken()
+    {
+        $api = $this->newApiResume(
+            array('HTTP_AUTHORIZATION' => 'Bearer nosuch:validator')
+        );
+
+        $auth = new Auth(new ArraySegment);
+        $this->assertFalse($api->resume($auth));
+        $this->assertTrue($auth->isAnon());
+    }
+
+    public function testResumeThrowsOnExpiredToken()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+        $this->storage->rows[$parsed['selector']]['expires'] = time() - 1;
+
+        $api = $this->newApiResume(
+            array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+        );
+
+        $this->expectException(TokenExpired::CLASS);
+        $api->resume(new Auth(new ArraySegment));
+    }
+
+    public function testEachRequestReauthenticatesIndependently()
+    {
+        // the stateless property: nothing carries over between requests, so a
+        // second "request" with no header is anonymous even though the first
+        // one authenticated
+        $value = $this->service->issue('boshag');
+
+        $first = new Auth(new ArraySegment);
+        $this->newApiResume(
+            array('HTTP_AUTHORIZATION' => 'Bearer ' . $value)
+        )->resume($first);
+        $this->assertTrue($first->isValid());
+
+        $second = new Auth(new ArraySegment);
+        $this->newApiResume(array())->resume($second);
+        $this->assertTrue($second->isAnon());
+    }
+}

--- a/tests/Session/ArraySegmentTest.php
+++ b/tests/Session/ArraySegmentTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace Aura\Auth\Session;
+
+use Aura\Auth\Auth;
+use Aura\Auth\Status;
+
+class ArraySegmentTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetAndSet()
+    {
+        $segment = new ArraySegment;
+        $this->assertNull($segment->get('nope'));
+        $this->assertSame('alt', $segment->get('nope', 'alt'));
+
+        $segment->set('key', 'val');
+        $this->assertSame('val', $segment->get('key'));
+    }
+
+    public function testConstructorSeedsValues()
+    {
+        $segment = new ArraySegment(array('key' => 'val'));
+        $this->assertSame('val', $segment->get('key'));
+    }
+
+    public function testStoredNullIsDistinctFromMissing()
+    {
+        $segment = new ArraySegment;
+        $segment->set('key', null);
+
+        // a stored null must not fall back to the alternative
+        $this->assertNull($segment->get('key', 'alt'));
+        $this->assertSame('alt', $segment->get('other', 'alt'));
+    }
+
+    public function testAuthRoundTripsWithoutASession()
+    {
+        // the point of the class: Segment::set() discards writes when there is
+        // no $_SESSION, so an authenticated user would read back as anonymous
+        // within the same request. This must not.
+        $this->assertFalse(isset($_SESSION));
+
+        $auth = new Auth(new ArraySegment);
+        $auth->set(Status::VALID, 1, 2, 'boshag', array('foo' => 'bar'));
+
+        $this->assertSame(Status::VALID, $auth->getStatus());
+        $this->assertSame('boshag', $auth->getUserName());
+        $this->assertSame(array('foo' => 'bar'), $auth->getUserData());
+        $this->assertTrue($auth->isValid());
+        $this->assertFalse($auth->isAnon());
+    }
+
+    public function testFreshAuthIsAnonymous()
+    {
+        $auth = new Auth(new ArraySegment);
+        $this->assertTrue($auth->isAnon());
+    }
+}

--- a/tests/Token/FakeTokenStorage.php
+++ b/tests/Token/FakeTokenStorage.php
@@ -10,6 +10,9 @@ class FakeTokenStorage implements TokenStorageInterface
 {
     public $rows = array();
 
+    /** Selectors passed to touch(), so tests can assert on redundant writes. */
+    public $touched = array();
+
     public function create(
         $selector,
         $hashed_validator,
@@ -40,6 +43,8 @@ class FakeTokenStorage implements TokenStorageInterface
 
     public function touch($selector, $now): void
     {
+        $this->touched[] = $selector;
+
         if (isset($this->rows[$selector])) {
             $this->rows[$selector]['last_used_at'] = (int) $now;
         }

--- a/tests/Token/FakeTokenStorage.php
+++ b/tests/Token/FakeTokenStorage.php
@@ -1,0 +1,71 @@
+<?php
+namespace Aura\Auth\Token;
+
+/**
+ *
+ * An in-memory TokenStorageInterface for tests.
+ *
+ */
+class FakeTokenStorage implements TokenStorageInterface
+{
+    public $rows = array();
+
+    public function create(
+        $selector,
+        $hashed_validator,
+        $username,
+        array $userdata,
+        $expires,
+        $created_at,
+        $label = null
+    ): void {
+        $this->rows[$selector] = array(
+            'selector' => $selector,
+            'hashed_validator' => $hashed_validator,
+            'username' => $username,
+            'userdata' => $userdata,
+            'label' => $label,
+            'expires' => (int) $expires,
+            'created_at' => (int) $created_at,
+            'last_used_at' => null,
+        );
+    }
+
+    public function findBySelector($selector): ?array
+    {
+        return isset($this->rows[$selector])
+            ? $this->rows[$selector]
+            : null;
+    }
+
+    public function touch($selector, $now): void
+    {
+        if (isset($this->rows[$selector])) {
+            $this->rows[$selector]['last_used_at'] = (int) $now;
+        }
+    }
+
+    public function deleteBySelector($selector): void
+    {
+        unset($this->rows[$selector]);
+    }
+
+    public function deleteByUsername($username): void
+    {
+        foreach ($this->rows as $selector => $row) {
+            if ($row['username'] === $username) {
+                unset($this->rows[$selector]);
+            }
+        }
+    }
+
+    public function deleteExpired(): void
+    {
+        $now = time();
+        foreach ($this->rows as $selector => $row) {
+            if ($row['expires'] < $now) {
+                unset($this->rows[$selector]);
+            }
+        }
+    }
+}

--- a/tests/Token/PdoTokenStorageTest.php
+++ b/tests/Token/PdoTokenStorageTest.php
@@ -1,0 +1,153 @@
+<?php
+namespace Aura\Auth\Token;
+
+use PDO;
+
+class PdoTokenStorageTest extends \PHPUnit\Framework\TestCase
+{
+    protected $pdo;
+
+    protected $storage;
+
+    protected function setUp() : void
+    {
+        if (false === extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped("Cannot test without the pdo_sqlite extension.");
+        }
+
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec(
+            "CREATE TABLE aura_auth_token (
+                selector VARCHAR(32) NOT NULL PRIMARY KEY,
+                hashed_validator VARCHAR(64) NOT NULL,
+                username VARCHAR(255) NOT NULL,
+                userdata TEXT NULL,
+                label VARCHAR(255) NULL,
+                expires INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                last_used_at INTEGER NULL
+            )"
+        );
+
+        $this->storage = new PdoTokenStorage($this->pdo);
+    }
+
+    public function testCreateAndFind()
+    {
+        $expires = time() + 100;
+        $created = time();
+        $this->storage->create(
+            'sel1',
+            'hash1',
+            'boshag',
+            array('scopes' => array('read:builds')),
+            $expires,
+            $created,
+            'CI deploy'
+        );
+
+        $row = $this->storage->findBySelector('sel1');
+        $this->assertSame('sel1', $row['selector']);
+        $this->assertSame('hash1', $row['hashed_validator']);
+        $this->assertSame('boshag', $row['username']);
+        $this->assertSame(array('scopes' => array('read:builds')), $row['userdata']);
+        $this->assertSame('CI deploy', $row['label']);
+        $this->assertSame($expires, $row['expires']);
+        $this->assertSame($created, $row['created_at']);
+        $this->assertNull($row['last_used_at']);
+    }
+
+    public function testCreateWithoutLabel()
+    {
+        $this->storage->create('sel1', 'hash1', 'boshag', array(), time() + 100, time());
+        $row = $this->storage->findBySelector('sel1');
+        $this->assertNull($row['label']);
+    }
+
+    public function testFindMissingReturnsNull()
+    {
+        $this->assertNull($this->storage->findBySelector('nope'));
+    }
+
+    public function testTouchIsNoopByDefault()
+    {
+        $this->storage->create('sel1', 'hash1', 'boshag', array(), time() + 100, time());
+        $this->storage->touch('sel1', time());
+
+        $row = $this->storage->findBySelector('sel1');
+        $this->assertNull($row['last_used_at']);
+    }
+
+    public function testTouchRecordsWhenTrackingEnabled()
+    {
+        $storage = new PdoTokenStorage($this->pdo, 'aura_auth_token', true);
+        $storage->create('sel1', 'hash1', 'boshag', array(), time() + 100, time());
+
+        $now = time();
+        $storage->touch('sel1', $now);
+
+        $row = $storage->findBySelector('sel1');
+        $this->assertSame($now, $row['last_used_at']);
+    }
+
+    public function testTouchMissingSelectorDoesNotError()
+    {
+        $storage = new PdoTokenStorage($this->pdo, 'aura_auth_token', true);
+        $storage->touch('nope', time());
+        $this->assertNull($storage->findBySelector('nope'));
+    }
+
+    public function testDeleteBySelector()
+    {
+        $this->storage->create('sel1', 'hash1', 'boshag', array(), time() + 100, time());
+        $this->storage->deleteBySelector('sel1');
+        $this->assertNull($this->storage->findBySelector('sel1'));
+    }
+
+    public function testDeleteByUsername()
+    {
+        $this->storage->create('sel1', 'hash1', 'boshag', array(), time() + 100, time());
+        $this->storage->create('sel2', 'hash2', 'boshag', array(), time() + 100, time());
+        $this->storage->create('sel3', 'hash3', 'other', array(), time() + 100, time());
+
+        $this->storage->deleteByUsername('boshag');
+
+        $this->assertNull($this->storage->findBySelector('sel1'));
+        $this->assertNull($this->storage->findBySelector('sel2'));
+        $this->assertNotNull($this->storage->findBySelector('sel3'));
+    }
+
+    public function testDeleteExpired()
+    {
+        $this->storage->create('live', 'hash1', 'boshag', array(), time() + 100, time());
+        $this->storage->create('dead', 'hash2', 'boshag', array(), time() - 100, time() - 200);
+
+        $this->storage->deleteExpired();
+
+        $this->assertNotNull($this->storage->findBySelector('live'));
+        $this->assertNull($this->storage->findBySelector('dead'));
+    }
+
+    public function testCustomTableName()
+    {
+        $this->pdo->exec(
+            "CREATE TABLE custom_tokens (
+                selector VARCHAR(32) NOT NULL PRIMARY KEY,
+                hashed_validator VARCHAR(64) NOT NULL,
+                username VARCHAR(255) NOT NULL,
+                userdata TEXT NULL,
+                label VARCHAR(255) NULL,
+                expires INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                last_used_at INTEGER NULL
+            )"
+        );
+
+        $storage = new PdoTokenStorage($this->pdo, 'custom_tokens');
+        $storage->create('sel1', 'hash1', 'boshag', array(), time() + 100, time());
+
+        $this->assertNotNull($storage->findBySelector('sel1'));
+        $this->assertNull($this->storage->findBySelector('sel1'));
+    }
+}

--- a/tests/Token/SplitTokenTest.php
+++ b/tests/Token/SplitTokenTest.php
@@ -1,15 +1,15 @@
 <?php
-namespace Aura\Auth\Remember;
+namespace Aura\Auth\Token;
 
 use Aura\Auth\Phpfunc;
 
-class TokenTest extends \PHPUnit\Framework\TestCase
+class SplitTokenTest extends \PHPUnit\Framework\TestCase
 {
     protected $token;
 
     protected function setUp() : void
     {
-        $this->token = new Token(new Phpfunc);
+        $this->token = new SplitToken(new Phpfunc);
     }
 
     public function testNewSelectorAndValidatorAreRandomHex()
@@ -19,22 +19,22 @@ class TokenTest extends \PHPUnit\Framework\TestCase
         $this->assertNotSame($this->token->newSelector(), $this->token->newSelector());
     }
 
-    public function testCookieValueRoundTrip()
+    public function testValueRoundTrip()
     {
-        $value = $this->token->makeCookieValue('sel', 'val');
+        $value = $this->token->makeValue('sel', 'val');
         $this->assertSame('sel:val', $value);
 
-        $parsed = $this->token->parseCookieValue($value);
+        $parsed = $this->token->parseValue($value);
         $this->assertSame('sel', $parsed['selector']);
         $this->assertSame('val', $parsed['validator']);
     }
 
     public function testParseRejectsMalformedValues()
     {
-        $this->assertNull($this->token->parseCookieValue(null));
-        $this->assertNull($this->token->parseCookieValue('nocolon'));
-        $this->assertNull($this->token->parseCookieValue(':novalidator'));
-        $this->assertNull($this->token->parseCookieValue('noselector:'));
+        $this->assertNull($this->token->parseValue(null));
+        $this->assertNull($this->token->parseValue('nocolon'));
+        $this->assertNull($this->token->parseValue(':novalidator'));
+        $this->assertNull($this->token->parseValue('noselector:'));
     }
 
     public function testVerify()

--- a/tests/Token/TokenServiceTest.php
+++ b/tests/Token/TokenServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aura\Auth\Token;
 
+use Aura\Auth\Exception\TokenExpired;
 use Aura\Auth\Phpfunc;
 
 class TokenServiceTest extends \PHPUnit\Framework\TestCase
@@ -107,15 +108,34 @@ class TokenServiceTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testVerifyRejectsExpiredToken()
+    public function testVerifyThrowsOnExpiredToken()
     {
         $value = $this->service->issue('boshag');
         $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
 
         // backdate the stored expiry rather than injecting a clock
+        $expired_at = time() - 1;
+        $this->storage->rows[$parsed['selector']]['expires'] = $expired_at;
+
+        try {
+            $this->service->verify($value);
+            $this->fail('Expected TokenExpired to be thrown.');
+        } catch (TokenExpired $e) {
+            $this->assertSame($expired_at, $e->getExpires());
+        }
+    }
+
+    public function testExpiredTokenWithBadValidatorReturnsNullRatherThanThrowing()
+    {
+        // the validator is matched before the expiry is looked at, so an
+        // attacker holding only a selector cannot learn that it exists
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
         $this->storage->rows[$parsed['selector']]['expires'] = time() - 1;
 
-        $this->assertNull($this->service->verify($value));
+        $this->assertNull(
+            $this->service->verify($parsed['selector'] . ':tampered')
+        );
     }
 
     public function testFailedVerifyDoesNotDeleteTheToken()
@@ -169,6 +189,16 @@ class TokenServiceTest extends \PHPUnit\Framework\TestCase
     public function testRevokeUnknownTokenReturnsFalse()
     {
         $this->assertFalse($this->service->revoke('nosuch:validator'));
+    }
+
+    public function testRevokeWorksOnAnExpiredToken()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+        $this->storage->rows[$parsed['selector']]['expires'] = time() - 1;
+
+        $this->assertTrue($this->service->revoke($value));
+        $this->assertNull($this->storage->findBySelector($parsed['selector']));
     }
 
     public function testRevokeBySelector()

--- a/tests/Token/TokenServiceTest.php
+++ b/tests/Token/TokenServiceTest.php
@@ -1,0 +1,210 @@
+<?php
+namespace Aura\Auth\Token;
+
+use Aura\Auth\Phpfunc;
+
+class TokenServiceTest extends \PHPUnit\Framework\TestCase
+{
+    protected $storage;
+
+    protected $service;
+
+    protected function setUp() : void
+    {
+        $this->storage = new FakeTokenStorage;
+        $this->service = new TokenService(
+            $this->storage,
+            new SplitToken(new Phpfunc)
+        );
+    }
+
+    public function testIssueReturnsParseableValueAndStoresOnlyTheHash()
+    {
+        $value = $this->service->issue('boshag');
+
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+        $this->assertNotNull($parsed);
+
+        $row = $this->storage->findBySelector($parsed['selector']);
+        $this->assertSame('boshag', $row['username']);
+
+        // the raw validator must not be recoverable from storage
+        $this->assertNotSame($parsed['validator'], $row['hashed_validator']);
+        $this->assertSame(
+            hash('sha256', $parsed['validator']),
+            $row['hashed_validator']
+        );
+    }
+
+    public function testIssueStoresUserdataAndLabel()
+    {
+        $value = $this->service->issue(
+            'boshag',
+            array('scopes' => array('read:builds')),
+            'CI deploy'
+        );
+
+        $row = $this->service->verify($value);
+        $this->assertSame(array('scopes' => array('read:builds')), $row['userdata']);
+        $this->assertSame('CI deploy', $row['label']);
+    }
+
+    public function testIssueUsesDefaultTtl()
+    {
+        $before = time();
+        $value = $this->service->issue('boshag');
+        $row = $this->service->verify($value);
+
+        $this->assertGreaterThanOrEqual($before + 2592000, $row['expires']);
+        $this->assertLessThanOrEqual(time() + 2592000, $row['expires']);
+    }
+
+    public function testIssueTtlOverride()
+    {
+        $before = time();
+        $value = $this->service->issue('boshag', array(), null, 60);
+        $row = $this->service->verify($value);
+
+        $this->assertGreaterThanOrEqual($before + 60, $row['expires']);
+        $this->assertLessThanOrEqual(time() + 60, $row['expires']);
+    }
+
+    public function testIssuedValuesAreUnique()
+    {
+        $this->assertNotSame(
+            $this->service->issue('boshag'),
+            $this->service->issue('boshag')
+        );
+    }
+
+    public function testVerifyReturnsTheRow()
+    {
+        $value = $this->service->issue('boshag');
+        $row = $this->service->verify($value);
+
+        $this->assertSame('boshag', $row['username']);
+    }
+
+    public function testVerifyRejectsMalformedValue()
+    {
+        $this->assertNull($this->service->verify('nocolon'));
+        $this->assertNull($this->service->verify(''));
+        $this->assertNull($this->service->verify(null));
+    }
+
+    public function testVerifyRejectsUnknownSelector()
+    {
+        $this->assertNull($this->service->verify('nosuch:validator'));
+    }
+
+    public function testVerifyRejectsTamperedValidator()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+
+        $this->assertNull(
+            $this->service->verify($parsed['selector'] . ':tampered')
+        );
+    }
+
+    public function testVerifyRejectsExpiredToken()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+
+        // backdate the stored expiry rather than injecting a clock
+        $this->storage->rows[$parsed['selector']]['expires'] = time() - 1;
+
+        $this->assertNull($this->service->verify($value));
+    }
+
+    public function testFailedVerifyDoesNotDeleteTheToken()
+    {
+        // a wrong validator must not be a way to revoke somebody else's token
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+
+        $this->service->verify($parsed['selector'] . ':tampered');
+
+        $this->assertNotNull($this->storage->findBySelector($parsed['selector']));
+        $this->assertNotNull($this->service->verify($value));
+    }
+
+    public function testVerifyTouchesTheToken()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+
+        $this->assertNull($this->storage->rows[$parsed['selector']]['last_used_at']);
+
+        $this->service->verify($value);
+
+        $this->assertSame(
+            time(),
+            $this->storage->rows[$parsed['selector']]['last_used_at']
+        );
+    }
+
+    public function testRevoke()
+    {
+        $value = $this->service->issue('boshag');
+
+        $this->assertTrue($this->service->revoke($value));
+        $this->assertNull($this->service->verify($value));
+    }
+
+    public function testRevokeRejectsTamperedValidator()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+
+        $this->assertFalse(
+            $this->service->revoke($parsed['selector'] . ':tampered')
+        );
+
+        // the real token still works
+        $this->assertNotNull($this->service->verify($value));
+    }
+
+    public function testRevokeUnknownTokenReturnsFalse()
+    {
+        $this->assertFalse($this->service->revoke('nosuch:validator'));
+    }
+
+    public function testRevokeBySelector()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+
+        $this->service->revokeBySelector($parsed['selector']);
+
+        $this->assertNull($this->service->verify($value));
+    }
+
+    public function testRevokeAll()
+    {
+        $one = $this->service->issue('boshag');
+        $two = $this->service->issue('boshag');
+        $other = $this->service->issue('other');
+
+        $this->service->revokeAll('boshag');
+
+        $this->assertNull($this->service->verify($one));
+        $this->assertNull($this->service->verify($two));
+        $this->assertNotNull($this->service->verify($other));
+    }
+
+    public function testDeleteExpired()
+    {
+        $live = $this->service->issue('boshag');
+        $dead = $this->service->issue('boshag');
+
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($dead);
+        $this->storage->rows[$parsed['selector']]['expires'] = time() - 1;
+
+        $this->service->deleteExpired();
+
+        $this->assertNotNull($this->service->verify($live));
+        $this->assertNull($this->storage->findBySelector($parsed['selector']));
+    }
+}

--- a/tests/Token/TokenServiceTest.php
+++ b/tests/Token/TokenServiceTest.php
@@ -191,6 +191,17 @@ class TokenServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->service->revoke('nosuch:validator'));
     }
 
+    public function testRevokeDoesNotTouchTheRowItIsAboutToDelete()
+    {
+        $value = $this->service->issue('boshag');
+        $parsed = (new SplitToken(new Phpfunc))->parseValue($value);
+
+        $this->service->revoke($value);
+
+        // nothing should have been written to a row on its way out
+        $this->assertSame(array(), $this->storage->touched);
+    }
+
     public function testRevokeWorksOnAnExpiredToken()
     {
         $value = $this->service->issue('boshag');


### PR DESCRIPTION
Fixes #110 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated remember-me cookies to use selector-and-validator split token values (`selector:validator`) for writing, parsing, and rotation.
  * Enhanced robustness of token parsing and malformed-token handling.
* **New Features**
  * Added stateless API token authentication with header-based login/resume, one-time token issuance, verification with expiry detection, and token revocation.
  * Introduced server-side API token storage via a token storage contract, including a PDO-backed implementation and optional last-use tracking.
* **Documentation**
  * Added an “API Tokens” guide to the documentation.
* **Tests**
  * Expanded coverage for tokens, header adapter behavior, stateless resume, and storage implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->