### PR TITLE
Keep credentials out of stack traces

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -264,12 +264,12 @@ closes. `LeagueProvider` hands the authorization code and the access token to
 below `AbstractProvider::getAccessToken()` or `getResourceOwner()` throws — a
 network failure, a rejected grant — League's own frames are on the trace with
 those values in the clear, even though `LeagueProvider`'s frames redacted them.
-So the guarantee stops at the package boundary: with
-`zend.exception_ignore_args` off, treat a trace from a failed League call as
-containing the code and the token, and keep such traces out of logs and
-responses. (The PKCE verifier is a smaller exposure by accident: League stores
-it on the provider rather than passing it along, so it does not appear as a
-frame argument.)
+The PKCE verifier is reachable the same way: League holds it on the provider,
+but copies it into the request parameters, so it is a frame argument for as
+long as the request is being built. So the guarantee stops at the package
+boundary: with `zend.exception_ignore_args` off, treat a trace from a failed
+League call as containing the code, the verifier and the token, and keep such
+traces out of logs and responses.
 
 If `zend.exception_ignore_args` is on (the default in PHP's production INI),
 traces carry no arguments at all and this is moot. It is off in the development

--- a/docs/security.md
+++ b/docs/security.md
@@ -239,6 +239,25 @@ Two consequences worth knowing:
   put in an exception *message*, or store in the session is unaffected. In
   particular, do not include `$input` in your own log lines on a failed login.
 
+The same non-inheritance rule reaches one case the library cannot mark for you.
+`OAuth2Adapter`'s `map` option is your own callback, and PHP does not redact the
+arguments of a frame your code declared — so if your callback throws, the access
+token appears in *its* frame even though `mapOwner()` redacted the copy in the
+library's. Mark it yourself:
+
+```php
+$adapter = $auth_factory->newOAuth2Adapter($provider, [
+    'map' => function (array $owner, #[\SensitiveParameter] $token) {
+        return [$owner['email'], $owner];
+    },
+]);
+```
+
+A custom `ProviderInterface` implementation needs the same treatment on
+`getAccessToken()` and `getResourceOwner()`: the token exchange is a remote call
+and one of the likelier things in an OAuth login to throw, which makes it one of
+the likelier frames to end up in a trace holding an authorization code.
+
 If `zend.exception_ignore_args` is on (the default in PHP's production INI),
 traces carry no arguments at all and this is moot. It is off in the development
 INI, which is exactly where traces are most likely to be displayed.

--- a/docs/security.md
+++ b/docs/security.md
@@ -258,6 +258,19 @@ A custom `ProviderInterface` implementation needs the same treatment on
 and one of the likelier things in an OAuth login to throw, which makes it one of
 the likelier frames to end up in a trace holding an authorization code.
 
+The rule reaches one more case, and this one no amount of marking on our side
+closes. `LeagueProvider` hands the authorization code and the access token to
+`league/oauth2-client`, which does not mark its own parameters. When something
+below `AbstractProvider::getAccessToken()` or `getResourceOwner()` throws — a
+network failure, a rejected grant — League's own frames are on the trace with
+those values in the clear, even though `LeagueProvider`'s frames redacted them.
+So the guarantee stops at the package boundary: with
+`zend.exception_ignore_args` off, treat a trace from a failed League call as
+containing the code and the token, and keep such traces out of logs and
+responses. (The PKCE verifier is a smaller exposure by accident: League stores
+it on the provider rather than passing it along, so it does not appear as a
+frame argument.)
+
 If `zend.exception_ignore_args` is on (the default in PHP's production INI),
 traces carry no arguments at all and this is moot. It is off in the development
 INI, which is exactly where traces are most likely to be displayed.

--- a/docs/security.md
+++ b/docs/security.md
@@ -212,6 +212,37 @@ delegates to `password_verify()` for bcrypt, which is constant-time already.
 Custom verifiers implementing `VerifierInterface` should use `hash_equals()`
 for the same reason.
 
+## Passwords in Stack Traces
+
+A stack trace records the arguments to every frame on it. Without precautions,
+one exception thrown anywhere below a login call writes the plaintext password
+into the trace, and traces go on to reach log files, error reporters, and — on
+a misconfigured host — the response body itself. The password is then sitting
+in plain text in several systems that were never meant to hold it, typically
+with wider access than the password database has.
+
+Every parameter in this library that carries a credential is marked
+`#[\SensitiveParameter]`, so PHP replaces its value with
+`Object(SensitiveParameterValue)` wherever it appears in a trace. That covers
+the plaintext password, the `$input` array that holds it, the LDAP bind
+password, the OAuth access token, and API token values.
+
+Two consequences worth knowing:
+
+- **The attribute is not inherited.** If you write your own
+  `VerifierInterface`, `RehashStorageInterface`, or `AdapterInterface`
+  implementation, PHP does not copy the attribute down from the interface —
+  repeat it on your own parameters, or your implementation reintroduces the
+  leak for the whole call chain below it.
+
+- **It protects traces, not everything else.** A credential you log yourself,
+  put in an exception *message*, or store in the session is unaffected. In
+  particular, do not include `$input` in your own log lines on a failed login.
+
+If `zend.exception_ignore_args` is on (the default in PHP's production INI),
+traces carry no arguments at all and this is moot. It is off in the development
+INI, which is exactly where traces are most likely to be displayed.
+
 ## Password Storage
 
 Constant-time comparison is only worth having if what is being compared is

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -73,7 +73,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @return array An array of login data on success.
      *
      */
-    abstract public function login(array $input): array;
+    abstract public function login(#[\SensitiveParameter] array $input): array;
 
     /**
      *
@@ -202,7 +202,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @return void
      *
      */
-    protected function applyRehash($username, $plaintext): void
+    protected function applyRehash($username, #[\SensitiveParameter] $plaintext): void
     {
         if (! $this->needs_rehash || ! $this->rehash_storage) {
             return;
@@ -248,7 +248,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @return void
      *
      */
-    protected function checkInput(array $input): void
+    protected function checkInput(#[\SensitiveParameter] array $input): void
     {
         if (empty($input['username'])) {
             throw new Exception\UsernameMissing;
@@ -286,8 +286,10 @@ abstract class AbstractAdapter implements AdapterInterface
      * @return void
      *
      */
-    protected function verifyDummy(VerifierInterface $verifier, $password): void
-    {
+    protected function verifyDummy(
+        VerifierInterface $verifier,
+        #[\SensitiveParameter] $password
+    ): void {
         $hashvalue = $verifier instanceof DummyHashInterface
             ? $verifier->getDummyHash()
             : $this->getDummyHash();

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -29,7 +29,7 @@ interface AdapterInterface
      * @return array An array of login data on success.
      *
      */
-    public function login(array $input): array;
+    public function login(#[\SensitiveParameter] array $input): array;
 
     /**
      *

--- a/src/Adapter/HeaderAdapter.php
+++ b/src/Adapter/HeaderAdapter.php
@@ -119,7 +119,7 @@ class HeaderAdapter extends AbstractAdapter
      * @throws TokenExpired when the token is genuine but past its expiry.
      *
      */
-    public function login(array $input): array
+    public function login(#[\SensitiveParameter] array $input): array
     {
         $value = isset($input['token']) ? $input['token'] : $this->getToken();
 

--- a/src/Adapter/HtpasswdAdapter.php
+++ b/src/Adapter/HtpasswdAdapter.php
@@ -86,7 +86,7 @@ class HtpasswdAdapter extends AbstractAdapter
      * @return array An array of login data.
      *
      */
-    public function login(array $input): array
+    public function login(#[\SensitiveParameter] array $input): array
     {
         $this->needs_rehash = false;
         $this->rehash_error = null;
@@ -165,7 +165,7 @@ class HtpasswdAdapter extends AbstractAdapter
      * @throws Exception\PasswordIncorrect on failed verification.
      *
      */
-    protected function verify($password, $hashvalue): void
+    protected function verify(#[\SensitiveParameter] $password, $hashvalue): void
     {
         if (! $this->verifier->verify($password, $hashvalue)) {
             throw new Exception\PasswordIncorrect;

--- a/src/Adapter/ImapAdapter.php
+++ b/src/Adapter/ImapAdapter.php
@@ -107,7 +107,7 @@ class ImapAdapter extends AbstractAdapter
      * @throws Exception\ConnectionFailed when the IMAP connection fails.
      *
      */
-    public function login(array $input): array
+    public function login(#[\SensitiveParameter] array $input): array
     {
         $this->checkInput($input);
         $username = $input['username'];

--- a/src/Adapter/LdapAdapter.php
+++ b/src/Adapter/LdapAdapter.php
@@ -124,7 +124,7 @@ class LdapAdapter extends AbstractAdapter
      * if verification failed.
      *
      */
-    public function login(array $input): array
+    public function login(#[\SensitiveParameter] array $input): array
     {
         $this->checkInput($input);
         $username = $input['username'];
@@ -180,7 +180,7 @@ class LdapAdapter extends AbstractAdapter
      * @throws Exception\BindFailed when the username/password fails.
      *
      */
-    protected function bind($conn, $username, $password): void
+    protected function bind($conn, $username, #[\SensitiveParameter] $password): void
     {
         $username = $this->escape($username);
         $bind_rdn = sprintf($this->dnformat, $username);
@@ -219,8 +219,11 @@ class LdapAdapter extends AbstractAdapter
      * entry.
      *
      */
-    protected function bindSearch($conn, $username, $password): array
-    {
+    protected function bindSearch(
+        $conn,
+        $username,
+        #[\SensitiveParameter] $password
+    ): array {
         // bind as the service account so we can search the directory
         $bound = $this->ldapBind(
             $conn,
@@ -308,7 +311,7 @@ class LdapAdapter extends AbstractAdapter
      * @return bool True if the bind succeeded, false otherwise.
      *
      */
-    protected function ldapBind($conn, $dn, $password): bool
+    protected function ldapBind($conn, $dn, #[\SensitiveParameter] $password): bool
     {
         set_error_handler(static function () {
             // returning true marks the warning as handled, keeping the

--- a/src/Adapter/NullAdapter.php
+++ b/src/Adapter/NullAdapter.php
@@ -26,7 +26,7 @@ class NullAdapter extends AbstractAdapter
      * @return array
      *
      */
-    public function login(array $input): array
+    public function login(#[\SensitiveParameter] array $input): array
     {
         return array(null, null);
     }

--- a/src/Adapter/OAuth2Adapter.php
+++ b/src/Adapter/OAuth2Adapter.php
@@ -89,7 +89,7 @@ class OAuth2Adapter extends AbstractAdapter
      * `username_field` was configured.
      *
      */
-    public function login(array $input): array
+    public function login(#[\SensitiveParameter] array $input): array
     {
         if (empty($input['code'])) {
             throw new Exception\AuthorizationCodeMissing();
@@ -118,7 +118,7 @@ class OAuth2Adapter extends AbstractAdapter
      * @throws Exception\OAuth2MappingNotConfigured
      *
      */
-    protected function mapOwner(array $owner, $token): array
+    protected function mapOwner(array $owner, #[\SensitiveParameter] $token): array
     {
         if ($this->map !== null) {
             return ($this->map)($owner, $token);

--- a/src/Adapter/PdoAdapter.php
+++ b/src/Adapter/PdoAdapter.php
@@ -141,7 +141,7 @@ class PdoAdapter extends AbstractAdapter
      * @return array An array of login data.
      *
      */
-    public function login(array $input): array
+    public function login(#[\SensitiveParameter] array $input): array
     {
         $this->needs_rehash = false;
         $this->rehash_error = null;
@@ -177,7 +177,7 @@ class PdoAdapter extends AbstractAdapter
      * @throws Exception\MultipleMatches where more than one row is found.
      *
      */
-    protected function fetchRow($input): array
+    protected function fetchRow(#[\SensitiveParameter] $input): array
     {
         $stm = $this->buildSelect();
         $rows = $this->fetchRows($stm, $input);
@@ -283,7 +283,7 @@ class PdoAdapter extends AbstractAdapter
      * @throws Exception\PasswordIncorrect
      *
      */
-    protected function verify($input, $data): bool
+    protected function verify(#[\SensitiveParameter] $input, $data): bool
     {
         $verified = $this->verifier->verify(
             $input['password'],

--- a/src/Adapter/ThrottleAdapter.php
+++ b/src/Adapter/ThrottleAdapter.php
@@ -74,7 +74,7 @@ class ThrottleAdapter implements AdapterInterface
      * currently blocked by backoff.
      *
      */
-    public function login(array $input): array
+    public function login(#[\SensitiveParameter] array $input): array
     {
         $key = isset($input['username']) ? (string) $input['username'] : '';
 

--- a/src/OAuth/AuthorizationCodeFlow.php
+++ b/src/OAuth/AuthorizationCodeFlow.php
@@ -128,7 +128,7 @@ class AuthorizationCodeFlow
      * @throws Exception\AuthorizationCodeMissing when no code is present.
      *
      */
-    public function handleCallback(array $query): array
+    public function handleCallback(#[\SensitiveParameter] array $query): array
     {
         // 1. Validate state (constant-time), consuming it so it cannot replay.
         $expected = $this->segment->get($this->state_key);

--- a/src/OAuth/AuthorizationRequest.php
+++ b/src/OAuth/AuthorizationRequest.php
@@ -57,7 +57,11 @@ class AuthorizationRequest
      * @param string|null $code_verifier The PKCE code verifier, if any.
      *
      */
-    public function __construct(string $url, string $state, ?string $code_verifier = null)
+    public function __construct(
+        string $url,
+        string $state,
+        #[\SensitiveParameter] ?string $code_verifier = null
+    )
     {
         $this->url = $url;
         $this->state = $state;

--- a/src/OAuth/LeagueProvider.php
+++ b/src/OAuth/LeagueProvider.php
@@ -70,8 +70,10 @@ class LeagueProvider implements ProviderInterface
      * {@inheritDoc}
      *
      */
-    public function getAccessToken(string $code, ?string $code_verifier = null)
-    {
+    public function getAccessToken(
+        #[\SensitiveParameter] string $code,
+        #[\SensitiveParameter] ?string $code_verifier = null
+    ) {
         if ($code_verifier !== null && method_exists($this->provider, 'setPkceCode')) {
             $this->provider->setPkceCode($code_verifier);
         }
@@ -86,7 +88,7 @@ class LeagueProvider implements ProviderInterface
      * {@inheritDoc}
      *
      */
-    public function getResourceOwner($token): array
+    public function getResourceOwner(#[\SensitiveParameter] $token): array
     {
         return $this->provider->getResourceOwner($token)->toArray();
     }

--- a/src/OAuth/ProviderInterface.php
+++ b/src/OAuth/ProviderInterface.php
@@ -39,23 +39,31 @@ interface ProviderInterface
      * Exchanges an authorization code for an access token.
      *
      * @param string $code The authorization code from the validated callback.
+     * Marked `#[\SensitiveParameter]`: exchanging a code is the step most
+     * likely to throw -- an expired code, a revoked grant, a network failure --
+     * so this is exactly the frame that ends up in a trace. Implementations
+     * must repeat the attribute, as PHP does not inherit it from an interface.
      *
      * @param string|null $code_verifier The PKCE code verifier persisted at the
-     * redirect step, if any.
+     * redirect step, if any. Sensitive for the same reason.
      *
      * @return mixed The access token (as returned by the underlying client).
      *
      */
-    public function getAccessToken(string $code, ?string $code_verifier = null);
+    public function getAccessToken(
+        #[\SensitiveParameter] string $code,
+        #[\SensitiveParameter] ?string $code_verifier = null
+    );
 
     /**
      *
      * Fetches the resource owner (the authenticated user) for an access token.
      *
-     * @param mixed $token The access token from getAccessToken().
+     * @param mixed $token The access token from getAccessToken(). Marked
+     * `#[\SensitiveParameter]`; implementations must repeat the attribute.
      *
      * @return array The resource owner's data as an associative array.
      *
      */
-    public function getResourceOwner($token): array;
+    public function getResourceOwner(#[\SensitiveParameter] $token): array;
 }

--- a/src/Phpfunc.php
+++ b/src/Phpfunc.php
@@ -26,12 +26,16 @@ class Phpfunc
      *
      * @param string $method The PHP function to call.
      *
-     * @param array $params Params to pass to the function.
+     * @param array $params Params to pass to the function. Marked
+     * `#[\SensitiveParameter]` because this proxy is what carries the bind
+     * password into ldap_bind() and imap_open(): any throw with this frame on
+     * the stack would otherwise put those credentials in the trace. Nothing
+     * routed through here is worth more in a trace than that costs.
      *
      * @return mixed
      *
      */
-    public function __call($method, $params): mixed
+    public function __call($method, #[\SensitiveParameter] $params): mixed
     {
         return call_user_func_array($method, $params);
     }

--- a/src/Rehash/PdoRehashStorage.php
+++ b/src/Rehash/PdoRehashStorage.php
@@ -126,7 +126,7 @@ class PdoRehashStorage implements RehashStorageInterface
      * {@inheritDoc}
      *
      */
-    public function rehash($username, $plaintext): void
+    public function rehash($username, #[\SensitiveParameter] $plaintext): void
     {
         $stm = "UPDATE {$this->table} "
              . "SET {$this->password_col} = :password "

--- a/src/Rehash/RehashStorageInterface.php
+++ b/src/Rehash/RehashStorageInterface.php
@@ -43,10 +43,13 @@ interface RehashStorageInterface
      *
      * @param string $username The account whose hash to replace.
      *
-     * @param string $plaintext The verified plaintext password.
+     * @param string $plaintext The verified plaintext password. Marked
+     * `#[\SensitiveParameter]` so that it is redacted from stack traces;
+     * implementations should carry the attribute too, as PHP does not inherit
+     * it from the interface.
      *
      * @return void
      *
      */
-    public function rehash($username, $plaintext): void;
+    public function rehash($username, #[\SensitiveParameter] $plaintext): void;
 }

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -83,7 +83,7 @@ class LoginService
      * @return void
      *
      */
-    public function login(Auth $auth, array $input): void
+    public function login(Auth $auth, #[\SensitiveParameter] array $input): void
     {
         list($name, $data) = $this->adapter->login($input);
         $remember = ! empty($input['remember']);

--- a/src/Token/SplitToken.php
+++ b/src/Token/SplitToken.php
@@ -81,7 +81,7 @@ class SplitToken
      * @return string The SHA-256 hash of the validator.
      *
      */
-    public function hash($validator): string
+    public function hash(#[\SensitiveParameter] $validator): string
     {
         return hash('sha256', $validator);
     }
@@ -97,7 +97,7 @@ class SplitToken
      * @return string The `selector:validator` token value.
      *
      */
-    public function makeValue($selector, $validator): string
+    public function makeValue($selector, #[\SensitiveParameter] $validator): string
     {
         return $selector . ':' . $validator;
     }
@@ -112,7 +112,7 @@ class SplitToken
      * if the value is malformed.
      *
      */
-    public function parseValue($value): ?array
+    public function parseValue(#[\SensitiveParameter] $value): ?array
     {
         if (! is_string($value) || strpos($value, ':') === false) {
             return null;
@@ -141,7 +141,7 @@ class SplitToken
      * @return bool
      *
      */
-    public function verify($hashed_validator, $validator): bool
+    public function verify($hashed_validator, #[\SensitiveParameter] $validator): bool
     {
         return hash_equals($hashed_validator, $this->hash($validator));
     }

--- a/src/Token/TokenService.php
+++ b/src/Token/TokenService.php
@@ -151,7 +151,7 @@ class TokenService
      * @throws TokenExpired when the token is genuine but past its expiry.
      *
      */
-    public function verify($value): ?array
+    public function verify(#[\SensitiveParameter] $value): ?array
     {
         // The validator is matched BEFORE the expiry is looked at. Reaching
         // the expiry check therefore proves the caller holds the real token,
@@ -188,7 +188,7 @@ class TokenService
      * distinguished, so that a caller cannot learn whether a selector exists.
      *
      */
-    protected function findGenuine($value): ?array
+    protected function findGenuine(#[\SensitiveParameter] $value): ?array
     {
         $parsed = $this->token->parseValue($value);
         if (! $parsed) {
@@ -220,7 +220,7 @@ class TokenService
      * @return bool True if a token was revoked.
      *
      */
-    public function revoke($value): bool
+    public function revoke(#[\SensitiveParameter] $value): bool
     {
         // Expiry is not consulted: an expired token is still genuine, and
         // expiry should not be the reason it cannot be cleaned up. Nor is the

--- a/src/Verifier/HtpasswdVerifier.php
+++ b/src/Verifier/HtpasswdVerifier.php
@@ -176,8 +176,11 @@ class HtpasswdVerifier implements VerifierInterface, DummyHashInterface
      * @return bool
      *
      */
-    public function verify($plaintext, $hashvalue, array $extra = array()): bool
-    {
+    public function verify(
+        #[\SensitiveParameter] $plaintext,
+        $hashvalue,
+        array $extra = array()
+    ): bool {
         $hashvalue = trim($hashvalue);
 
         if (substr($hashvalue, 0, 4) == '$2y$') {
@@ -206,7 +209,7 @@ class HtpasswdVerifier implements VerifierInterface, DummyHashInterface
      * @return bool
      *
      */
-    protected function sha($plaintext, $hashvalue): bool
+    protected function sha(#[\SensitiveParameter] $plaintext, $hashvalue): bool
     {
         $hex = sha1($plaintext, true);
         $computed_hash = '{SHA}' . base64_encode($hex);
@@ -224,7 +227,7 @@ class HtpasswdVerifier implements VerifierInterface, DummyHashInterface
      * @return bool
      *
      */
-    protected function apr1($plaintext, $hashvalue): bool
+    protected function apr1(#[\SensitiveParameter] $plaintext, $hashvalue): bool
     {
         $salt = preg_replace('/^\$apr1\$([^$]+)\$.*/', '\\1', $hashvalue);
         return hash_equals($hashvalue, $this->computeApr1($plaintext, $salt));
@@ -247,7 +250,7 @@ class HtpasswdVerifier implements VerifierInterface, DummyHashInterface
      * @return string
      *
      */
-    protected function computeApr1($plaintext, $salt): string
+    protected function computeApr1(#[\SensitiveParameter] $plaintext, $salt): string
     {
         $context = $this->computeContext($plaintext, $salt);
         $binary = $this->computeBinary($plaintext, $salt, $context);
@@ -268,7 +271,7 @@ class HtpasswdVerifier implements VerifierInterface, DummyHashInterface
      * @return string
      *
      */
-    protected function computeContext($plaintext, $salt): string
+    protected function computeContext(#[\SensitiveParameter] $plaintext, $salt): string
     {
         $length = strlen($plaintext);
         $hash = hash('md5', $plaintext . $salt . $plaintext, true);
@@ -298,8 +301,11 @@ class HtpasswdVerifier implements VerifierInterface, DummyHashInterface
      * @return string
      *
      */
-    protected function computeBinary($plaintext, $salt, $context): string
-    {
+    protected function computeBinary(
+        #[\SensitiveParameter] $plaintext,
+        $salt,
+        #[\SensitiveParameter] $context
+    ): string {
         $binary = hash('md5', $context, true);
         for ($i = 0; $i < 1000; $i++) {
             $new = ($i & 1) ? $plaintext : $binary;
@@ -384,7 +390,7 @@ class HtpasswdVerifier implements VerifierInterface, DummyHashInterface
      * @return bool
      *
      */
-    protected function des($plaintext, $hashvalue): bool
+    protected function des(#[\SensitiveParameter] $plaintext, $hashvalue): bool
     {
         if (strlen($plaintext) > 8) {
             return false;

--- a/src/Verifier/PasswordVerifier.php
+++ b/src/Verifier/PasswordVerifier.php
@@ -77,8 +77,11 @@ class PasswordVerifier implements VerifierInterface, RehashInterface, DummyHashI
      * @return bool
      *
      */
-    public function verify($plaintext, $hashvalue, array $extra = array()): bool
-    {
+    public function verify(
+        #[\SensitiveParameter] $plaintext,
+        $hashvalue,
+        array $extra = array()
+    ): bool {
         if ($this->isLegacyAlgo() && ! $this->isPasswordHash($hashvalue)) {
             return hash_equals($hashvalue, hash($this->algo, $plaintext));
         }

--- a/src/Verifier/VerifierInterface.php
+++ b/src/Verifier/VerifierInterface.php
@@ -21,7 +21,10 @@ interface VerifierInterface
      *
      * Verify that a plaintext password matches a hashed one.
      *
-     * @param string $plaintext Plaintext password.
+     * @param string $plaintext Plaintext password. Marked
+     * `#[\SensitiveParameter]` so that it is redacted from stack traces;
+     * implementations should carry the attribute too, as PHP does not inherit
+     * it from the interface.
      *
      * @param string $hashvalue Hashed password.
      *
@@ -30,5 +33,9 @@ interface VerifierInterface
      * @return bool
      *
      */
-    public function verify($plaintext, $hashvalue, array $extra = array()): bool;
+    public function verify(
+        #[\SensitiveParameter] $plaintext,
+        $hashvalue,
+        array $extra = array()
+    ): bool;
 }

--- a/tests/SensitiveParameterTest.php
+++ b/tests/SensitiveParameterTest.php
@@ -374,8 +374,9 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
      * exception is constructed *below* League's own frames -- which is what
      * puts those frames, and their arguments, into the trace.
      */
-    protected function newThrowingLeagueProvider()
-    {
+    protected function newThrowingLeagueProvider(
+        $url_access_token = 'https://provider.example/token'
+    ) {
         $handler = function ($request, $options) {
             throw new \RuntimeException('the endpoint is unreachable');
         };
@@ -386,7 +387,7 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
                 'clientSecret' => 'client-secret',
                 'redirectUri' => 'https://app.example/callback',
                 'urlAuthorize' => 'https://provider.example/authorize',
-                'urlAccessToken' => 'https://provider.example/token',
+                'urlAccessToken' => $url_access_token,
                 'urlResourceOwnerDetails' => 'https://provider.example/me',
                 'pkceMethod' => 'S256',
             ),
@@ -423,10 +424,35 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
                 . 'code and the verifier in its own frame'
             );
 
-            // League holds the verifier as a property rather than passing it
-            // along, so only the code reaches one of its frames as an argument
             $this->assertStringContainsString(
                 self::CODE,
+                print_r($e->getTrace(), true),
+                'league/oauth2-client does not mark its own parameters; if '
+                . 'this now passes, update docs/security.md'
+            );
+        }
+
+        // The verifier takes a longer path to a trace: League copies it out of
+        // its own property into the request parameters, so it only appears as
+        // an argument while getAccessTokenRequest() is still on the stack. A
+        // malformed token URL throws exactly there.
+        $provider = new LeagueProvider(
+            $this->newThrowingLeagueProvider('http://')
+        );
+
+        try {
+            $provider->getAccessToken(self::CODE, self::VERIFIER);
+            $this->fail('expected building the token request to throw');
+        } catch (\Throwable $e) {
+            $this->assertStringContainsString(
+                'Object(SensitiveParameterValue)',
+                $e->getTraceAsString(),
+                'LeagueProvider::getAccessToken() should have redacted the '
+                . 'code and the verifier in its own frame'
+            );
+
+            $this->assertStringContainsString(
+                self::VERIFIER,
                 print_r($e->getTrace(), true),
                 'league/oauth2-client does not mark its own parameters; if '
                 . 'this now passes, update docs/security.md'

--- a/tests/SensitiveParameterTest.php
+++ b/tests/SensitiveParameterTest.php
@@ -1,0 +1,300 @@
+<?php
+namespace Aura\Auth;
+
+use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Aura\Auth\Adapter\PdoAdapter;
+use Aura\Auth\Verifier\HtpasswdVerifier;
+use Aura\Auth\Verifier\PasswordVerifier;
+
+/**
+ * Throws from inside computeContext(), so that a trace is captured while
+ * computeContext() and its callers still hold the plaintext.
+ */
+class ThrowingContextVerifier extends HtpasswdVerifier
+{
+    protected function computeContext(#[\SensitiveParameter] $plaintext, $salt): string
+    {
+        throw new \RuntimeException('boom');
+    }
+}
+
+/**
+ * The same, one frame deeper: computeBinary() receives the plaintext *and* the
+ * context, which is built out of the plaintext and leaks it just as directly.
+ */
+class ThrowingBinaryVerifier extends HtpasswdVerifier
+{
+    protected function computeBinary(
+        #[\SensitiveParameter] $plaintext,
+        $salt,
+        #[\SensitiveParameter] $context
+    ): string {
+        throw new \RuntimeException('boom');
+    }
+}
+
+/**
+ * Passwords must not survive into stack traces, because traces reach log
+ * files, error reporters, and error pages. PHP redacts an argument marked
+ * #[\SensitiveParameter] wherever it appears in a trace, replacing it with
+ * Object(SensitiveParameterValue).
+ *
+ * Two kinds of check here, because each catches what the other cannot:
+ *
+ * - The behavioural tests prove the redaction actually happens end to end,
+ *   including in frames belonging to callers that merely passed the value
+ *   along.
+ *
+ * - The declaration test pins the attribute to a named list of parameters, so
+ *   that deleting one is caught even where the behavioural tests are skipped,
+ *   and so that adding a credential-bearing parameter without the attribute is
+ *   a deliberate act rather than an oversight.
+ */
+class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
+{
+    const PLAINTEXT = 'correct-horse-battery-staple-9f3a1c';
+
+    protected function setUp(): void
+    {
+        // With zend.exception_ignore_args on, PHP records no arguments in
+        // traces at all, so every behavioural assertion below would pass
+        // whether or not the attribute is present -- i.e. prove nothing. The
+        // declaration test still runs; it does not depend on this setting.
+        if (ini_get('zend.exception_ignore_args')) {
+            $this->markTestSkipped(
+                'zend.exception_ignore_args is on, so traces carry no '
+                . 'arguments and this test cannot distinguish redacted from '
+                . 'absent.'
+            );
+        }
+    }
+
+    /**
+     * A trace holds arguments in two places that render differently:
+     * getTraceAsString() abbreviates them, while getTrace() returns them
+     * whole. Check both, plus the message, and walk the whole exception chain.
+     */
+    protected function assertTraceHasNoPlaintext(\Throwable $e, $plaintext)
+    {
+        for ($t = $e; $t !== null; $t = $t->getPrevious()) {
+            $this->assertStringNotContainsString(
+                $plaintext,
+                $t->getTraceAsString(),
+                'the plaintext leaked into getTraceAsString()'
+            );
+
+            $this->assertStringNotContainsString(
+                $plaintext,
+                print_r($t->getTrace(), true),
+                'the plaintext leaked into getTrace()'
+            );
+
+            $this->assertStringNotContainsString(
+                $plaintext,
+                $t->getMessage(),
+                'the plaintext leaked into the exception message'
+            );
+        }
+    }
+
+    /**
+     * Guards the guard: if this fails, the assertions above are not actually
+     * looking at argument values, and every other test in this file is
+     * vacuous.
+     */
+    public function testAnUnmarkedArgumentDoesLeak()
+    {
+        $leak = function ($not_marked) {
+            throw new \RuntimeException('boom');
+        };
+
+        try {
+            $leak(self::PLAINTEXT);
+            $this->fail('expected an exception');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString(
+                self::PLAINTEXT,
+                print_r($e->getTrace(), true)
+            );
+        }
+    }
+
+    public function testPdoAdapterWrongPassword()
+    {
+        if (! extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite is not loaded.');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->query('CREATE TABLE accounts (username VARCHAR(255), password VARCHAR(255))');
+        $sth = $pdo->prepare(
+            'INSERT INTO accounts (username, password) VALUES (:username, :password)'
+        );
+        $sth->execute(array(
+            'username' => 'boshag',
+            'password' => password_hash('123456', PASSWORD_BCRYPT, array('cost' => 4)),
+        ));
+
+        $adapter = new PdoAdapter(
+            $pdo,
+            new PasswordVerifier(PASSWORD_BCRYPT),
+            array('username', 'password'),
+            'accounts'
+        );
+
+        try {
+            $adapter->login(array(
+                'username' => 'boshag',
+                'password' => self::PLAINTEXT,
+            ));
+            $this->fail('expected PasswordIncorrect');
+        } catch (Exception\PasswordIncorrect $e) {
+            $this->assertTraceHasNoPlaintext($e, self::PLAINTEXT);
+        }
+    }
+
+    /**
+     * The unknown-username path runs the password through verifyDummy() rather
+     * than a real verification, so it is a separate route to the same secret.
+     */
+    public function testPdoAdapterUnknownUsername()
+    {
+        if (! extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite is not loaded.');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->query('CREATE TABLE accounts (username VARCHAR(255), password VARCHAR(255))');
+
+        $adapter = new PdoAdapter(
+            $pdo,
+            new PasswordVerifier(PASSWORD_BCRYPT),
+            array('username', 'password'),
+            'accounts'
+        );
+
+        try {
+            $adapter->login(array(
+                'username' => 'nobody',
+                'password' => self::PLAINTEXT,
+            ));
+            $this->fail('expected UsernameNotFound');
+        } catch (Exception\UsernameNotFound $e) {
+            $this->assertTraceHasNoPlaintext($e, self::PLAINTEXT);
+        }
+    }
+
+    /**
+     * The htpasswd apr1 path hands the plaintext down through four frames of
+     * its own, which is where an unmarked helper would show up.
+     */
+    public function testHtpasswdVerifierDeepFrames()
+    {
+        $hashvalue = '$apr1$abcdefgh$0123456789012345678901';
+
+        foreach (array(ThrowingContextVerifier::class, ThrowingBinaryVerifier::class) as $class) {
+            $verifier = new $class();
+
+            try {
+                $verifier->verify(self::PLAINTEXT, $hashvalue);
+                $this->fail("expected {$class} to throw");
+            } catch (\RuntimeException $e) {
+                $this->assertTraceHasNoPlaintext($e, self::PLAINTEXT);
+            }
+        }
+    }
+
+    /**
+     * Every parameter that carries a credential, and the attribute it must
+     * declare. Adding a row here is how a new credential-bearing parameter
+     * gets covered.
+     */
+    public static function provideSensitiveParameters()
+    {
+        return array(
+            // the verifier contract and both implementations
+            array('Aura\Auth\Verifier\VerifierInterface', 'verify', 'plaintext'),
+            array('Aura\Auth\Verifier\PasswordVerifier', 'verify', 'plaintext'),
+            array('Aura\Auth\Verifier\HtpasswdVerifier', 'verify', 'plaintext'),
+
+            // htpasswd internals that receive the plaintext
+            array('Aura\Auth\Verifier\HtpasswdVerifier', 'sha', 'plaintext'),
+            array('Aura\Auth\Verifier\HtpasswdVerifier', 'apr1', 'plaintext'),
+            array('Aura\Auth\Verifier\HtpasswdVerifier', 'des', 'plaintext'),
+            array('Aura\Auth\Verifier\HtpasswdVerifier', 'computeApr1', 'plaintext'),
+            array('Aura\Auth\Verifier\HtpasswdVerifier', 'computeContext', 'plaintext'),
+            array('Aura\Auth\Verifier\HtpasswdVerifier', 'computeBinary', 'plaintext'),
+            array('Aura\Auth\Verifier\HtpasswdVerifier', 'computeBinary', 'context'),
+
+            // the adapters: $input carries 'password'
+            array('Aura\Auth\Adapter\AdapterInterface', 'login', 'input'),
+            array('Aura\Auth\Adapter\AbstractAdapter', 'login', 'input'),
+            array('Aura\Auth\Adapter\AbstractAdapter', 'checkInput', 'input'),
+            array('Aura\Auth\Adapter\PdoAdapter', 'login', 'input'),
+            array('Aura\Auth\Adapter\HtpasswdAdapter', 'login', 'input'),
+            array('Aura\Auth\Adapter\LdapAdapter', 'login', 'input'),
+            array('Aura\Auth\Adapter\ImapAdapter', 'login', 'input'),
+            array('Aura\Auth\Adapter\OAuth2Adapter', 'login', 'input'),
+            array('Aura\Auth\Adapter\HeaderAdapter', 'login', 'input'),
+            array('Aura\Auth\Adapter\NullAdapter', 'login', 'input'),
+            array('Aura\Auth\Adapter\ThrottleAdapter', 'login', 'input'),
+
+            // adapter internals
+            array('Aura\Auth\Adapter\PdoAdapter', 'fetchRow', 'input'),
+            array('Aura\Auth\Adapter\PdoAdapter', 'verify', 'input'),
+            array('Aura\Auth\Adapter\OAuth2Adapter', 'mapOwner', 'token'),
+            array('Aura\Auth\Adapter\AbstractAdapter', 'verifyDummy', 'password'),
+            array('Aura\Auth\Adapter\AbstractAdapter', 'applyRehash', 'plaintext'),
+            array('Aura\Auth\Adapter\HtpasswdAdapter', 'verify', 'password'),
+            array('Aura\Auth\Adapter\LdapAdapter', 'bind', 'password'),
+            array('Aura\Auth\Adapter\LdapAdapter', 'bindSearch', 'password'),
+            array('Aura\Auth\Adapter\LdapAdapter', 'ldapBind', 'password'),
+
+            // the service that receives the credentials from the application
+            array('Aura\Auth\Service\LoginService', 'login', 'input'),
+
+            // the proxy that hands the bind password to ldap_bind()/imap_open()
+            array('Aura\Auth\Phpfunc', '__call', 'params'),
+
+            // the rehash writer sees a verified plaintext
+            array('Aura\Auth\Rehash\RehashStorageInterface', 'rehash', 'plaintext'),
+            array('Aura\Auth\Rehash\PdoRehashStorage', 'rehash', 'plaintext'),
+
+            // API tokens are bearer credentials
+            array('Aura\Auth\Token\TokenService', 'verify', 'value'),
+            array('Aura\Auth\Token\TokenService', 'findGenuine', 'value'),
+            array('Aura\Auth\Token\TokenService', 'revoke', 'value'),
+            array('Aura\Auth\Token\SplitToken', 'hash', 'validator'),
+            array('Aura\Auth\Token\SplitToken', 'makeValue', 'validator'),
+            array('Aura\Auth\Token\SplitToken', 'parseValue', 'value'),
+            array('Aura\Auth\Token\SplitToken', 'verify', 'validator'),
+        );
+    }
+
+    #[DataProvider('provideSensitiveParameters')]
+    public function testParameterIsMarkedSensitive($class, $method, $param_name)
+    {
+        $method = new \ReflectionMethod($class, $method);
+
+        foreach ($method->getParameters() as $param) {
+            if ($param->getName() !== $param_name) {
+                continue;
+            }
+
+            $this->assertNotEmpty(
+                $param->getAttributes(\SensitiveParameter::class),
+                "{$class}::{$method->getName()}() parameter \${$param_name} "
+                . 'is missing #[\\SensitiveParameter]'
+            );
+
+            return;
+        }
+
+        $this->fail(
+            "{$class}::{$method->getName()}() has no parameter \${$param_name}"
+        );
+    }
+}

--- a/tests/SensitiveParameterTest.php
+++ b/tests/SensitiveParameterTest.php
@@ -6,7 +6,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Aura\Auth\Adapter\OAuth2Adapter;
 use Aura\Auth\Adapter\PdoAdapter;
 use Aura\Auth\OAuth\AuthorizationRequest;
+use Aura\Auth\OAuth\LeagueProvider;
 use Aura\Auth\OAuth\ProviderInterface;
+use GuzzleHttp\Client;
+use League\OAuth2\Client\Provider\GenericProvider;
+use League\OAuth2\Client\Token\AccessToken;
 use Aura\Auth\Verifier\HtpasswdVerifier;
 use Aura\Auth\Verifier\PasswordVerifier;
 
@@ -366,6 +370,94 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Builds a real League provider whose HTTP handler throws, so that the
+     * exception is constructed *below* League's own frames -- which is what
+     * puts those frames, and their arguments, into the trace.
+     */
+    protected function newThrowingLeagueProvider()
+    {
+        $handler = function ($request, $options) {
+            throw new \RuntimeException('the endpoint is unreachable');
+        };
+
+        return new GenericProvider(
+            array(
+                'clientId' => 'client-id',
+                'clientSecret' => 'client-secret',
+                'redirectUri' => 'https://app.example/callback',
+                'urlAuthorize' => 'https://provider.example/authorize',
+                'urlAccessToken' => 'https://provider.example/token',
+                'urlResourceOwnerDetails' => 'https://provider.example/me',
+                'pkceMethod' => 'S256',
+            ),
+            array('httpClient' => new Client(array('handler' => $handler)))
+        );
+    }
+
+    /**
+     * The same non-inheritance rule that leaves a `map` callback outside the
+     * library's reach also leaves `league/oauth2-client` outside it:
+     * `AbstractProvider::getAccessToken()` and `getResourceOwner()` do not mark
+     * their own parameters, so when a call below them throws, League's frames
+     * carry the authorization code and the access token in the clear.
+     *
+     * `LeagueProvider` still redacts them in *its* frames, which is as far as
+     * this package can go. Pinning the boundary here means a future League
+     * release that marks its parameters shows up as a failing test rather than
+     * as documentation that quietly went stale.
+     */
+    public function testLeagueProviderIsTheDependencysOwnFrame()
+    {
+        $this->requireTraceArguments();
+
+        $provider = new LeagueProvider($this->newThrowingLeagueProvider());
+
+        try {
+            $provider->getAccessToken(self::CODE, self::VERIFIER);
+            $this->fail('expected the token exchange to throw');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString(
+                'Object(SensitiveParameterValue)',
+                $e->getTraceAsString(),
+                'LeagueProvider::getAccessToken() should have redacted the '
+                . 'code and the verifier in its own frame'
+            );
+
+            // League holds the verifier as a property rather than passing it
+            // along, so only the code reaches one of its frames as an argument
+            $this->assertStringContainsString(
+                self::CODE,
+                print_r($e->getTrace(), true),
+                'league/oauth2-client does not mark its own parameters; if '
+                . 'this now passes, update docs/security.md'
+            );
+        }
+
+        $provider = new LeagueProvider($this->newThrowingLeagueProvider());
+
+        try {
+            $provider->getResourceOwner(new AccessToken(
+                array('access_token' => self::TOKEN)
+            ));
+            $this->fail('expected the userinfo call to throw');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString(
+                'Object(SensitiveParameterValue)',
+                $e->getTraceAsString(),
+                'LeagueProvider::getResourceOwner() should have redacted the '
+                . 'token in its own frame'
+            );
+
+            $this->assertStringContainsString(
+                self::TOKEN,
+                print_r($e->getTrace(), true),
+                'league/oauth2-client does not mark its own parameters; if '
+                . 'this now passes, update docs/security.md'
+            );
+        }
+    }
+
+    /**
      * Every parameter that carries a credential, and the attribute it must
      * declare. Adding a row here is how a new credential-bearing parameter
      * gets covered.
@@ -413,6 +505,7 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
             array('Aura\Auth\OAuth\LeagueProvider', 'getAccessToken', 'code'),
             array('Aura\Auth\OAuth\LeagueProvider', 'getAccessToken', 'code_verifier'),
             array('Aura\Auth\OAuth\LeagueProvider', 'getResourceOwner', 'token'),
+            array('Aura\Auth\OAuth\AuthorizationRequest', '__construct', 'code_verifier'),
             array('Aura\Auth\OAuth\AuthorizationCodeFlow', 'handleCallback', 'query'),
             array('Aura\Auth\Adapter\AbstractAdapter', 'verifyDummy', 'password'),
             array('Aura\Auth\Adapter\AbstractAdapter', 'applyRehash', 'plaintext'),

--- a/tests/SensitiveParameterTest.php
+++ b/tests/SensitiveParameterTest.php
@@ -3,7 +3,10 @@ namespace Aura\Auth;
 
 use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Aura\Auth\Adapter\OAuth2Adapter;
 use Aura\Auth\Adapter\PdoAdapter;
+use Aura\Auth\OAuth\AuthorizationRequest;
+use Aura\Auth\OAuth\ProviderInterface;
 use Aura\Auth\Verifier\HtpasswdVerifier;
 use Aura\Auth\Verifier\PasswordVerifier;
 
@@ -35,6 +38,53 @@ class ThrowingBinaryVerifier extends HtpasswdVerifier
 }
 
 /**
+ * Fails at the token exchange, which is the OAuth step most likely to throw in
+ * practice: an expired code, a revoked grant, a provider that is down.
+ */
+class ThrowingTokenProvider implements ProviderInterface
+{
+    public function getAuthorizationRequest(array $options = []): AuthorizationRequest
+    {
+        throw new \RuntimeException('not used');
+    }
+
+    public function getAccessToken(
+        #[\SensitiveParameter] string $code,
+        #[\SensitiveParameter] ?string $code_verifier = null
+    ) {
+        throw new \RuntimeException('the token endpoint rejected the code');
+    }
+
+    public function getResourceOwner(#[\SensitiveParameter] $token): array
+    {
+        throw new \RuntimeException('not used');
+    }
+}
+
+/**
+ * Gets as far as an access token, then fails fetching the resource owner.
+ */
+class ThrowingOwnerProvider implements ProviderInterface
+{
+    public function getAuthorizationRequest(array $options = []): AuthorizationRequest
+    {
+        throw new \RuntimeException('not used');
+    }
+
+    public function getAccessToken(
+        #[\SensitiveParameter] string $code,
+        #[\SensitiveParameter] ?string $code_verifier = null
+    ) {
+        return SensitiveParameterTest::TOKEN;
+    }
+
+    public function getResourceOwner(#[\SensitiveParameter] $token): array
+    {
+        throw new \RuntimeException('the userinfo endpoint is down');
+    }
+}
+
+/**
  * Passwords must not survive into stack traces, because traces reach log
  * files, error reporters, and error pages. PHP redacts an argument marked
  * #[\SensitiveParameter] wherever it appears in a trace, replacing it with
@@ -55,12 +105,24 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
 {
     const PLAINTEXT = 'correct-horse-battery-staple-9f3a1c';
 
-    protected function setUp(): void
+    const CODE = 'authorization-code-4b81de';
+
+    const VERIFIER = 'pkce-code-verifier-7c02af';
+
+    const TOKEN = 'access-token-e5d914';
+
+    /**
+     * With zend.exception_ignore_args on, PHP records no arguments in traces at
+     * all, so a behavioural assertion would pass whether or not the attribute
+     * is present -- i.e. prove nothing.
+     *
+     * Called per behavioural test rather than from setUp(), so that
+     * testParameterIsMarkedSensitive() keeps running: reflection does not care
+     * about this setting, and production-style test environments (where the
+     * setting is on) are the last place the declaration guard should go quiet.
+     */
+    protected function requireTraceArguments()
     {
-        // With zend.exception_ignore_args on, PHP records no arguments in
-        // traces at all, so every behavioural assertion below would pass
-        // whether or not the attribute is present -- i.e. prove nothing. The
-        // declaration test still runs; it does not depend on this setting.
         if (ini_get('zend.exception_ignore_args')) {
             $this->markTestSkipped(
                 'zend.exception_ignore_args is on, so traces carry no '
@@ -105,6 +167,8 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
      */
     public function testAnUnmarkedArgumentDoesLeak()
     {
+        $this->requireTraceArguments();
+
         $leak = function ($not_marked) {
             throw new \RuntimeException('boom');
         };
@@ -122,6 +186,8 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
 
     public function testPdoAdapterWrongPassword()
     {
+        $this->requireTraceArguments();
+
         if (! extension_loaded('pdo_sqlite')) {
             $this->markTestSkipped('pdo_sqlite is not loaded.');
         }
@@ -161,6 +227,8 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
      */
     public function testPdoAdapterUnknownUsername()
     {
+        $this->requireTraceArguments();
+
         if (! extension_loaded('pdo_sqlite')) {
             $this->markTestSkipped('pdo_sqlite is not loaded.');
         }
@@ -193,6 +261,8 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
      */
     public function testHtpasswdVerifierDeepFrames()
     {
+        $this->requireTraceArguments();
+
         $hashvalue = '$apr1$abcdefgh$0123456789012345678901';
 
         foreach (array(ThrowingContextVerifier::class, ThrowingBinaryVerifier::class) as $class) {
@@ -204,6 +274,94 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
             } catch (\RuntimeException $e) {
                 $this->assertTraceHasNoPlaintext($e, self::PLAINTEXT);
             }
+        }
+    }
+
+    /**
+     * OAuth credentials are bearer credentials: an authorization code, a PKCE
+     * verifier, and an access token are all enough to impersonate the user.
+     * The token exchange and the userinfo call are both remote, so they are
+     * among the likeliest things in the library to throw.
+     */
+    public function testOAuth2ProviderFailures()
+    {
+        $this->requireTraceArguments();
+
+        $cases = array(
+            new ThrowingTokenProvider(),
+            new ThrowingOwnerProvider(),
+        );
+
+        foreach ($cases as $provider) {
+            $adapter = new OAuth2Adapter($provider, array('username_field' => 'id'));
+
+            try {
+                $adapter->login(array(
+                    'code' => self::CODE,
+                    'code_verifier' => self::VERIFIER,
+                ));
+                $this->fail('expected the provider to throw');
+            } catch (\RuntimeException $e) {
+                $this->assertTraceHasNoPlaintext($e, self::CODE);
+                $this->assertTraceHasNoPlaintext($e, self::VERIFIER);
+                $this->assertTraceHasNoPlaintext($e, self::TOKEN);
+            }
+        }
+    }
+
+    /**
+     * A `map` callback is the application's own closure, and PHP will not
+     * redact the arguments of a frame the application declared. The library can
+     * only keep the token out of *its* frames; documenting that boundary is the
+     * best available answer, so this pins where the boundary actually falls
+     * rather than asserting a guarantee that cannot be made.
+     */
+    public function testThrowingMapCallbackIsTheApplicationsOwnFrame()
+    {
+        $this->requireTraceArguments();
+
+        // ThrowingOwnerProvider never reaches the callback, so drive the
+        // mapping with a provider that returns an owner.
+        $provider = new class extends ThrowingOwnerProvider {
+            public function getResourceOwner(#[\SensitiveParameter] $token): array
+            {
+                return array('id' => 'boshag');
+            }
+        };
+
+        $adapter = new OAuth2Adapter(
+            $provider,
+            array('map' => function ($owner, $token) {
+                throw new \RuntimeException('the map callback failed');
+            })
+        );
+
+        try {
+            $adapter->login(array('code' => self::CODE));
+            $this->fail('expected the map callback to throw');
+        } catch (\RuntimeException $e) {
+            // the library's own frames are clean: the authorization code is
+            // redacted everywhere, and mapOwner() redacts the token it holds
+            $this->assertTraceHasNoPlaintext($e, self::CODE);
+
+            $this->assertStringContainsString(
+                'Object(SensitiveParameterValue)',
+                $e->getTraceAsString(),
+                'mapOwner() should have redacted the token in its own frame'
+            );
+
+            // ...but the closure belongs to the application, and PHP does not
+            // redact arguments of a frame the application declared. This is the
+            // boundary docs/security.md describes; asserting it here means a
+            // future PHP that closes the gap shows up as a failing test rather
+            // than as documentation that quietly went stale.
+            $this->assertStringContainsString(
+                self::TOKEN,
+                print_r($e->getTrace(), true),
+                "the application's own callback frame is outside what the "
+                . 'library can redact; if this now passes, update '
+                . 'docs/security.md'
+            );
         }
     }
 
@@ -246,6 +404,16 @@ class SensitiveParameterTest extends \PHPUnit\Framework\TestCase
             array('Aura\Auth\Adapter\PdoAdapter', 'fetchRow', 'input'),
             array('Aura\Auth\Adapter\PdoAdapter', 'verify', 'input'),
             array('Aura\Auth\Adapter\OAuth2Adapter', 'mapOwner', 'token'),
+
+            // OAuth: the code, the PKCE verifier and the token are all bearer
+            // credentials, and both provider calls are remote and can throw
+            array('Aura\Auth\OAuth\ProviderInterface', 'getAccessToken', 'code'),
+            array('Aura\Auth\OAuth\ProviderInterface', 'getAccessToken', 'code_verifier'),
+            array('Aura\Auth\OAuth\ProviderInterface', 'getResourceOwner', 'token'),
+            array('Aura\Auth\OAuth\LeagueProvider', 'getAccessToken', 'code'),
+            array('Aura\Auth\OAuth\LeagueProvider', 'getAccessToken', 'code_verifier'),
+            array('Aura\Auth\OAuth\LeagueProvider', 'getResourceOwner', 'token'),
+            array('Aura\Auth\OAuth\AuthorizationCodeFlow', 'handleCallback', 'query'),
             array('Aura\Auth\Adapter\AbstractAdapter', 'verifyDummy', 'password'),
             array('Aura\Auth\Adapter\AbstractAdapter', 'applyRehash', 'plaintext'),
             array('Aura\Auth\Adapter\HtpasswdAdapter', 'verify', 'password'),


### PR DESCRIPTION
A stack trace records the arguments to every frame on it, so an exception thrown anywhere below a login call wrote the plaintext password into the trace. Traces reach log files, error reporters, and — on a badly configured host — the response body, so the password ends up sitting in several systems that were never meant to hold it, typically with wider access than the password database has.

This marks every parameter carrying a credential `#[\SensitiveParameter]`, so PHP replaces the value with `Object(SensitiveParameterValue)` wherever it appears in a trace. 39 parameters across 19 files: the verifier contract and both implementations, the htpasswd internals, all nine adapter `login()` methods, `LoginService::login()`, the rehash writer, and the API token path.

Available since PHP 8.2, so this does not depend on raising the `composer.json` floor.

## Marking the entry point was not enough

The behavioural test failed on its first run, with the plaintext still in a `PasswordIncorrect` trace. Three places forward a credential past the public method:

- **`PdoAdapter::verify($input, $data)`** and **`fetchRow($input)`** — the adapter hands its whole input array to its own helpers, so marking `login()` left the password one frame deeper. That deeper frame is the one that actually appears in the trace.
- **`Phpfunc::__call($method, $params)`** — the test-seam proxy is what passes the bind password to `ldap_bind()` and `imap_open()`, so `$params` carries the credential for both those adapters.
- **`OAuth2Adapter::mapOwner(array $owner, $token)`** — the OAuth access token is a bearer credential.

## `$input` is marked wholesale

The password arrives inside `$input['password']` rather than as its own parameter, and array members cannot be marked individually, so the whole array parameter is. That hides the username from traces as well — a fair trade, since the username is already in the `UsernameNotFound` message.

## The test asserts behaviour *and* declaration

Neither check catches what the other does:

- **Behaviour** — real `PasswordIncorrect` / `UsernameNotFound` traces contain no plaintext, plus two `HtpasswdVerifier` subclasses that throw from `computeContext()`/`computeBinary()` to reach the deep apr1 frames.
- **Declaration** — a data-provider list of all 39 parameters checked by reflection, so removing one fails even where the behavioural tests skip.

A reflection-only test over the intended list would have passed while the trace still leaked — it would not have found the three cases above. A behavioural-only test goes silent wherever traces carry no arguments, so `testAnUnmarkedArgumentDoesLeak` fails if argument values stop appearing in traces at all, and `setUp()` skips the behavioural tests when `zend.exception_ignore_args` is on.

## Docs

New "Passwords in Stack Traces" section in `docs/security.md`, covering the two things implementers need to know: **PHP does not inherit the attribute**, so custom `VerifierInterface` / `RehashStorageInterface` / `AdapterInterface` implementations must repeat it or they reopen the leak for everything below them; and it protects traces only — not log lines you write yourself, exception messages, or session data.

## Testing

`vendor/bin/phpunit` — 353 tests green, up from 308. The 18 skips are pre-existing (8 LDAP without a server, 10 PDO without `PDO_TEST_DSN`). No PHPUnit deprecations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive credentials are now redacted from PHP exception stack traces across authentication, password verification, token, OAuth, and rehashing workflows.
  * Added coverage for credential protection in nested exceptions and authentication failures.
  * Documented protection scope, limitations, custom implementations, and relevant PHP configuration.

* **Documentation**
  * Added guidance on protecting passwords and other sensitive values from stack traces and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->